### PR TITLE
Correcting the mixing model with quarantine

### DIFF
--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -27,7 +27,7 @@
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
 #define EPIWORLD_VERSION_MINOR 11
-#define EPIWORLD_VERSION_PATCH 2
+#define EPIWORLD_VERSION_PATCH 3
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;
 static const int epiworld_version_minor = EPIWORLD_VERSION_MINOR;
@@ -31364,10 +31364,13 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_infected_list()
 
     std::fill(n_infected_per_group.begin(), n_infected_per_group.end(), 0u);
 
-    for (auto & a : agents)
+    // Resetting the number of available contacts
+    adjusted_contact_rate.assign(this->entities.size(), 0.0);
+
+    for (const auto & a : agents)
     {
 
-        if (a.get_state() == ModelSEIRMixingQuarantine<TSeq>::INFECTED)
+        if (a.get_state() == INFECTED)
         {
             if (a.get_n_entities() > 0u)
             {
@@ -31382,6 +31385,29 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_infected_list()
             }
         }
 
+        // Setting how many agents are available for contact
+        if (
+            ((a.get_state() < ISOLATED) || (a.get_state() == RECOVERED)) &&
+            (a.get_n_entities() > 0u)
+        )
+        {
+            adjusted_contact_rate[
+                a.get_entity(0u).get_id()
+            ] += 1.0;
+        }
+
+    }
+
+    // This simplifies calculations later
+    for (auto & rate: adjusted_contact_rate)
+    {
+        if (rate > 0.0)
+            rate = Model<TSeq>::get_param("Contact rate") / rate;
+        else
+            rate = 0.0;  // No available contacts in this group
+
+        if (rate > 1.0)
+            rate = 1.0;
     }
 
     return;
@@ -31531,23 +31557,23 @@ inline void ModelSEIRMixingQuarantine<TSeq>::reset()
 
     }
 
-    // Adjusting contact rate
-    adjusted_contact_rate.clear();
-    adjusted_contact_rate.resize(this->entities.size(), 0.0);
+    // // Adjusting contact rate
+    // adjusted_contact_rate.clear();
+    // adjusted_contact_rate.resize(this->entities.size(), 0.0);
 
-    for (size_t i = 0u; i < this->entities.size(); ++i)
-    {
+    // for (size_t i = 0u; i < this->entities.size(); ++i)
+    // {
 
-        adjusted_contact_rate[i] =
-            Model<TSeq>::get_param("Contact rate") /
-                static_cast< epiworld_double > (this->get_entity(i).size());
+    //     adjusted_contact_rate[i] =
+    //         Model<TSeq>::get_param("Contact rate") /
+    //             static_cast< epiworld_double > (this->get_entity(i).size());
 
 
-        // Possibly correcting for a small number of agents
-        if (adjusted_contact_rate[i] > 1.0)
-            adjusted_contact_rate[i] = 1.0;
+    //     // Possibly correcting for a small number of agents
+    //     if (adjusted_contact_rate[i] > 1.0)
+    //         adjusted_contact_rate[i] = 1.0;
 
-    }
+    // }
 
     this->m_update_infected_list();
 

--- a/include/epiworld/epiworld.hpp
+++ b/include/epiworld/epiworld.hpp
@@ -27,7 +27,7 @@
 /* Versioning */
 #define EPIWORLD_VERSION_MAJOR 0
 #define EPIWORLD_VERSION_MINOR 11
-#define EPIWORLD_VERSION_PATCH 2
+#define EPIWORLD_VERSION_PATCH 3
 
 static const int epiworld_version_major = EPIWORLD_VERSION_MAJOR;
 static const int epiworld_version_minor = EPIWORLD_VERSION_MINOR;


### PR DESCRIPTION
This PR patches the mixing model with quarantine by applying the same correction previously used in the measles models. The correction has to do with how the number of contacts changes as a function of the quarantined agents.