### PR TITLE
Cleaning (simplifying) a couple of models

### DIFF
--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -25069,9 +25069,9 @@ private:
     // Where the agents start in the `infected` vector
     std::vector< size_t > entity_indices;
 
-    void m_update_infected_list();
+    void _update_infected_list();
     std::vector< size_t > sampled_agents;
-    size_t sample_agents(
+    size_t _sample_agents(
         Agent<TSeq> * agent,
         std::vector< size_t > & sampled_agents
         );
@@ -25083,14 +25083,14 @@ private:
     #endif
 
     // Update functions
-    static void m_update_susceptible(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_exposed(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_infected(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_isolated(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_quarantine_suscep(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_quarantine_exposed(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_hospitalized(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_isolated_recovered(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_susceptible(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_exposed(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_infected(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_isolated(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_quarantine_suscep(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_quarantine_exposed(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_hospitalized(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_isolated_recovered(Agent<TSeq> * p, Model<TSeq> * m);
 
     // Data about the quarantine process
     std::vector< bool > quarantine_willingness; ///< Indicator
@@ -25100,8 +25100,7 @@ private:
     std::vector< int > day_onset; ///< Day of onset of the disease
     std::vector< int > day_exposed; ///< Day of exposure
 
-    void m_quarantine_process();
-    static void m_update_model(Model<TSeq> * m);
+    static void _quarantine_process(Model<TSeq> * m);
 
 public:
 
@@ -25120,51 +25119,6 @@ public:
     static const size_t QUARANTINE_PROCESS_DONE     = 2u;
 
     ModelSEIRMixingQuarantine() {};
-
-    /**
-     * @brief Constructs a ModelSEIRMixingQuarantine object.
-     *
-     * @param model A reference to an existing ModelSEIRMixingQuarantine object.
-     * @param vname The name of the ModelSEIRMixingQuarantine object.
-     * @param n The number of entities in the model.
-     * @param prevalence The initial prevalence of the disease in the model.
-     * @param contact_rate The contact rate between entities in the model.
-     * @param transmission_rate The transmission rate of the disease in the model.
-     * @param avg_incubation_days The average incubation period of the disease in the model.
-     * @param recovery_rate The recovery rate of the disease in the model.
-     * @param contact_matrix The contact matrix between entities in the model. Specified in
-     * column-major order.
-     * @param hospitalization_rate The rate at which infected individuals are hospitalized.
-     * @param hospitalization_period The average duration of hospitalization in days.
-     * @param days_undetected The average number of days an infected individual remains undetected.
-     * @param quarantine_period The duration of quarantine in days for exposed contacts.
-     * @param quarantine_willingness The proportion of individuals willing to comply with quarantine measures.
-     * @param isolation_willingness The proportion of individuals willing to self-isolate when detected.
-     * @param isolation_period The duration of isolation in days for detected infected individuals.
-     * @param contact_tracing_success_rate The probability of successfully identifying and tracing contacts (default: 1.0).
-     * @param contact_tracing_days_prior The number of days prior to detection for which contacts are traced (default: 4).
-     */
-    ModelSEIRMixingQuarantine(
-        ModelSEIRMixingQuarantine<TSeq> & model,
-        const std::string & vname,
-        epiworld_fast_uint n,
-        epiworld_double prevalence,
-        epiworld_double contact_rate,
-        epiworld_double transmission_rate,
-        epiworld_double avg_incubation_days,
-        epiworld_double recovery_rate,
-        std::vector< double > contact_matrix,
-        epiworld_double hospitalization_rate,
-        epiworld_double hospitalization_period,
-        // Policy parameters
-        epiworld_double days_undetected,
-        epiworld_fast_int quarantine_period,
-        epiworld_double quarantine_willingness,
-        epiworld_double isolation_willingness,
-        epiworld_fast_int isolation_period,
-        epiworld_double contact_tracing_success_rate = 1.0,
-        epiworld_fast_uint contact_tracing_days_prior = 4u
-    );
 
     /**
      * @brief Constructs a ModelSEIRMixingQuarantine object.
@@ -25277,20 +25231,12 @@ public:
         return isolation_willingness;
     };
 
+    void next() override;
+
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_model(Model<TSeq> * m)
-{
-    auto * model = model_cast<ModelSEIRMixingQuarantine<TSeq>, TSeq>(m);
-    model->m_quarantine_process();
-    model->events_run();
-    model->m_update_infected_list();
-    return;
-}
-
-template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_infected_list()
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_infected_list()
 {
 
     auto & agents = this->get_agents();
@@ -25348,7 +25294,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_infected_list()
 }
 
 template<typename TSeq>
-inline size_t ModelSEIRMixingQuarantine<TSeq>::sample_agents(
+inline size_t ModelSEIRMixingQuarantine<TSeq>::_sample_agents(
     Agent<TSeq> * agent,
     std::vector< size_t > & sampled_agents
     )
@@ -25474,25 +25420,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::reset()
 
     }
 
-    // // Adjusting contact rate
-    // adjusted_contact_rate.clear();
-    // adjusted_contact_rate.resize(this->entities.size(), 0.0);
-
-    // for (size_t i = 0u; i < this->entities.size(); ++i)
-    // {
-
-    //     adjusted_contact_rate[i] =
-    //         Model<TSeq>::get_param("Contact rate") /
-    //             static_cast< epiworld_double > (this->get_entity(i).size());
-
-
-    //     // Possibly correcting for a small number of agents
-    //     if (adjusted_contact_rate[i] > 1.0)
-    //         adjusted_contact_rate[i] = 1.0;
-
-    // }
-
-    this->m_update_infected_list();
+    this->_update_infected_list();
 
     // Setting up the quarantine parameters
     quarantine_willingness.resize(this->size(), false);
@@ -25523,7 +25451,7 @@ inline std::unique_ptr<Model<TSeq>> ModelSEIRMixingQuarantine<TSeq>::clone_ptr()
 }
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_susceptible(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_susceptible(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -25590,7 +25518,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_susceptible(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_exposed(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_exposed(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -25613,7 +25541,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_exposed(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_infected(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_infected(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -25692,7 +25620,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_infected(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_isolated(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_isolated(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -25747,7 +25675,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_isolated(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_quarantine_suscep(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_quarantine_suscep(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -25771,7 +25699,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_quarantine_suscep(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_quarantine_exposed(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_quarantine_exposed(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -25816,7 +25744,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_quarantine_exposed(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_isolated_recovered(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_isolated_recovered(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -25840,7 +25768,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_isolated_recovered(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_hospitalized(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_hospitalized(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -25851,52 +25779,56 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_hospitalized(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_quarantine_process() {
+inline void ModelSEIRMixingQuarantine<TSeq>::_quarantine_process(Model<TSeq> * m) {
+
+    auto * model = model_cast<ModelSEIRMixingQuarantine<TSeq>, TSeq>(m);
 
     // Process entity-level quarantine
-    for (size_t agent_i = 0u; agent_i < this->size(); ++agent_i)
+    for (size_t agent_i = 0u; agent_i < m->size(); ++agent_i)
     {
 
         // Checking if the quarantine in the agent was triggered
         // or not
         if (
-            agent_quarantine_triggered[agent_i] !=
+            model->agent_quarantine_triggered[agent_i] !=
             ModelSEIRMixingQuarantine<TSeq>::QUARANTINE_PROCESS_ACTIVE
         )
             continue;
 
-        if (this->par("Quarantine period") < 0)
+        if (m->par("Quarantine period") < 0)
         {
-            agent_quarantine_triggered[agent_i] = QUARANTINE_PROCESS_DONE;
+            model->agent_quarantine_triggered[agent_i] =
+            ModelSEIRMixingQuarantine<TSeq>::QUARANTINE_PROCESS_DONE;
             continue;
         }
 
         // Getting the number of contacts, if it is greater
         // than the maximum, it means that we overflowed, so
         // we will only quarantine the first EPI_MAX_TRACKING
-        size_t n_contacts = this->contact_tracing->get_n_contacts(agent_i);
+        auto ct = m->get_contact_tracing();
+        size_t n_contacts = ct.get_n_contacts(agent_i);
         if (n_contacts >= EPI_MAX_TRACKING)
             n_contacts = EPI_MAX_TRACKING;
 
-        auto success_rate = this->par("Contact tracing success rate");
-        auto days_prior = this->par("Contact tracing days prior");
+        auto success_rate = m->par("Contact tracing success rate");
+        auto days_prior = m->par("Contact tracing days prior");
         for (size_t contact_i = 0u; contact_i < n_contacts; ++contact_i)
         {
 
             // Checking if we will detect the contact
-            if (this->runif() > success_rate)
+            if (m->runif() > success_rate)
                 continue;
 
-            auto [contact_id, contact_date] = this->contact_tracing->get_contact(
+            auto [contact_id, contact_date] = ct.get_contact(
                 agent_i, contact_i
             );
 
             // Skip contacts outside the tracing window
-            if ((static_cast<double>(this->today()) -
+            if ((static_cast<double>(m->today()) -
                 static_cast<double>(contact_date)) > days_prior)
                 continue;
 
-            auto & agent = Model<TSeq>::get_agent(contact_id);
+            auto & agent = m->get_agent(contact_id);
 
             if (agent.get_state() > INFECTED)
                 continue;
@@ -25905,24 +25837,24 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_quarantine_process() {
             if (agent.get_n_tools() != 0u)
                 continue;
 
-            if (quarantine_willingness[contact_id])
+            if (model->quarantine_willingness[contact_id])
             {
 
                 switch (agent.get_state())
                 {
                     case SUSCEPTIBLE:
-                        agent.change_state(*this, QUARANTINED_SUSCEPTIBLE);
-                        day_flagged[contact_id] = this->today();
+                        agent.change_state(*m, ModelSEIRMixingQuarantine<TSeq>::QUARANTINED_SUSCEPTIBLE);
+                        model->day_flagged[contact_id] = m->today();
                         break;
                     case EXPOSED:
-                        agent.change_state(*this, QUARANTINED_EXPOSED);
-                        day_flagged[contact_id] = this->today();
+                        agent.change_state(*m, ModelSEIRMixingQuarantine<TSeq>::QUARANTINED_EXPOSED);
+                        model->day_flagged[contact_id] = m->today();
                         break;
                     case INFECTED:
-                        if (isolation_willingness[contact_id])
+                        if (model->isolation_willingness[contact_id])
                         {
-                            agent.change_state(*this, ISOLATED);
-                            day_flagged[contact_id] = this->today();
+                            agent.change_state(*m, ModelSEIRMixingQuarantine<TSeq>::ISOLATED);
+                            model->day_flagged[contact_id] = m->today();
                         }
                         break;
                     default:
@@ -25935,7 +25867,8 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_quarantine_process() {
         }
 
         // Setting the quarantine process off
-        agent_quarantine_triggered[agent_i] = QUARANTINE_PROCESS_DONE;
+        model->agent_quarantine_triggered[agent_i] =
+            ModelSEIRMixingQuarantine<TSeq>::QUARANTINE_PROCESS_DONE;
     }
 
     return;
@@ -25965,7 +25898,6 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_quarantine_process() {
  */
 template<typename TSeq>
 inline ModelSEIRMixingQuarantine<TSeq>::ModelSEIRMixingQuarantine(
-    ModelSEIRMixingQuarantine<TSeq> & model,
     const std::string & vname,
     epiworld_fast_uint n,
     epiworld_double prevalence,
@@ -25991,117 +25923,66 @@ inline ModelSEIRMixingQuarantine<TSeq>::ModelSEIRMixingQuarantine(
     this->contact_matrix = contact_matrix;
 
     // Setting up parameters
-    model.add_param(contact_rate, "Contact rate");
-    model.add_param(transmission_rate, "Prob. Transmission");
-    model.add_param(recovery_rate, "Prob. Recovery");
-    model.add_param(avg_incubation_days, "Avg. Incubation days");
-    model.add_param(hospitalization_rate, "Hospitalization rate");
-    model.add_param(hospitalization_period, "Hospitalization period");
-    model.add_param(days_undetected, "Days undetected");
-    model.add_param(quarantine_period, "Quarantine period");
-    model.add_param(
+    this->add_param(contact_rate, "Contact rate");
+    this->add_param(transmission_rate, "Prob. Transmission");
+    this->add_param(recovery_rate, "Prob. Recovery");
+    this->add_param(avg_incubation_days, "Avg. Incubation days");
+    this->add_param(hospitalization_rate, "Hospitalization rate");
+    this->add_param(hospitalization_period, "Hospitalization period");
+    this->add_param(days_undetected, "Days undetected");
+    this->add_param(quarantine_period, "Quarantine period");
+    this->add_param(
         quarantine_willingness, "Quarantine willingness"
     );
-    model.add_param(
+    this->add_param(
         isolation_willingness, "Isolation willingness"
     );
-    model.add_param(isolation_period, "Isolation period");
-    model.add_param(
+    this->add_param(isolation_period, "Isolation period");
+    this->add_param(
         contact_tracing_success_rate, "Contact tracing success rate"
     );
-    model.add_param(
+    this->add_param(
         contact_tracing_days_prior, "Contact tracing days prior"
     );
 
     // state
-    model.add_state("Susceptible", m_update_susceptible);
-    model.add_state("Exposed", m_update_exposed);
-    model.add_state("Infected", m_update_infected);
-    model.add_state("Isolated", m_update_isolated);
-    model.add_state("Quarantined Susceptible", m_update_quarantine_suscep);
-    model.add_state("Quarantined Exposed", m_update_quarantine_exposed);
-    model.add_state("Isolated Recovered", m_update_isolated_recovered);
-    model.add_state("Hospitalized", m_update_hospitalized);
-    model.add_state("Recovered");
+    this->add_state("Susceptible", _update_susceptible);
+    this->add_state("Exposed", _update_exposed);
+    this->add_state("Infected", _update_infected);
+    this->add_state("Isolated", _update_isolated);
+    this->add_state("Quarantined Susceptible", _update_quarantine_suscep);
+    this->add_state("Quarantined Exposed", _update_quarantine_exposed);
+    this->add_state("Isolated Recovered", _update_isolated_recovered);
+    this->add_state("Hospitalized", _update_hospitalized);
+    this->add_state("Recovered");
 
     // Global function
-    model.add_globalevent(this->m_update_model, "Update infected individuals");
-    model.queuing_off();
+    this->add_globalevent(
+        this->_quarantine_process,
+        "Update infected individuals"
+    );
+
+    this->queuing_off();
 
     // Preparing the virus -------------------------------------------
     Virus<TSeq> virus(vname, prevalence, true);
-    virus.set_state(
-        ModelSEIRMixingQuarantine<TSeq>::EXPOSED,
-        ModelSEIRMixingQuarantine<TSeq>::RECOVERED,
-        ModelSEIRMixingQuarantine<TSeq>::RECOVERED
-        );
+    virus.set_state(EXPOSED, RECOVERED, RECOVERED);
 
     virus.set_prob_infecting("Prob. Transmission");
     virus.set_prob_recovery("Prob. Recovery");
     virus.set_incubation("Avg. Incubation days");
 
-    model.add_virus(virus);
+    this->add_virus(virus);
 
-    model.queuing_off(); // No queuing need
+    this->queuing_off(); // No queuing need
 
     // Enable contact tracing for quarantine process
-    model.contact_tracing_on(EPI_MAX_TRACKING);
+    this->contact_tracing_on(EPI_MAX_TRACKING);
 
     // Adding the empty population
-    model.agents_empty_graph(n);
+    this->agents_empty_graph(n);
 
-    model.set_name("SEIR with Mixing and Quarantine");
-
-    return;
-
-}
-
-template<typename TSeq>
-inline ModelSEIRMixingQuarantine<TSeq>::ModelSEIRMixingQuarantine(
-    const std::string & vname,
-    epiworld_fast_uint n,
-    epiworld_double prevalence,
-    epiworld_double contact_rate,
-    epiworld_double transmission_rate,
-    epiworld_double avg_incubation_days,
-    epiworld_double recovery_rate,
-    std::vector< double > contact_matrix,
-    epiworld_double hospitalization_rate,
-    epiworld_double hospitalization_period,
-    // Policy parameters
-    epiworld_double days_undetected,
-    epiworld_fast_int quarantine_period,
-    epiworld_double quarantine_willingness,
-    epiworld_double isolation_willingness,
-    epiworld_fast_int isolation_period,
-    epiworld_double contact_tracing_success_rate,
-    epiworld_fast_uint contact_tracing_days_prior
-    )
-{
-
-    this->contact_matrix = contact_matrix;
-
-    ModelSEIRMixingQuarantine(
-        *this,
-        vname,
-        n,
-        prevalence,
-        contact_rate,
-        transmission_rate,
-        avg_incubation_days,
-        recovery_rate,
-        contact_matrix,
-        hospitalization_rate,
-        hospitalization_period,
-        // Policy parameters
-        days_undetected,
-        quarantine_period,
-        quarantine_willingness,
-        isolation_willingness,
-        isolation_period,
-        contact_tracing_success_rate,
-        contact_tracing_days_prior
-    );
+    this->set_name("SEIR with Mixing and Quarantine");
 
     return;
 
@@ -26121,6 +26002,16 @@ inline ModelSEIRMixingQuarantine<TSeq> & ModelSEIRMixingQuarantine<TSeq>::initia
     return *this;
 
 }
+
+
+template<typename TSeq>
+inline void ModelSEIRMixingQuarantine<TSeq>::next() {
+
+    this->_update_infected_list();
+    Model<TSeq>::next();
+
+}
+
 #undef MM
 #endif
 /*//////////////////////////////////////////////////////////////////////////////
@@ -27985,7 +27876,7 @@ private:
     double m_get_risk_period(size_t agent_id);
 
     // Update the list of infectious agents
-    void m_update_infectious_list();
+    void _update_infectious_list();
 
     // Vector to hold sampled agents temporarily
     std::vector< size_t > sampled_agents;
@@ -28011,17 +27902,17 @@ private:
     #endif
 
     // Update functions
-    static void m_update_susceptible(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_latent(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_prodromal(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_rash(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_isolated(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_isolated_recovered(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_quarantine_suscep(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_quarantine_latent(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_quarantine_prodromal(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_quarantine_recovered(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_hospitalized(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_susceptible(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_latent(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_prodromal(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_rash(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_isolated(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_isolated_recovered(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_quarantine_suscep(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_quarantine_latent(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_quarantine_prodromal(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_quarantine_recovered(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_hospitalized(Agent<TSeq> * p, Model<TSeq> * m);
 
     // Data about the quarantine process
     std::vector< bool > quarantine_willingness; ///< Indicator for quarantine willingness
@@ -28038,9 +27929,7 @@ private:
     
     std::vector< int > quarantine_risk_level; ///< Risk level assigned to each agent (0=low, 1=medium, 2=high)
     
-    void m_quarantine_process(); ///< Overall quarantine process
-
-    static void m_update_model(Model<TSeq> * m);
+    static void _quarantine_process(Model<TSeq> * m); ///< Overall quarantine process
 
     std::vector< size_t > days_quarantine_triggered; ///< Days when quarantine was triggered
 
@@ -28201,26 +28090,11 @@ public:
         return days_quarantine_triggered;
     };
 
+    void next() override;
+
 };
 
 // Implementation starts here
-
-template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_model(
-    Model<TSeq> * m
-)
-{
-    auto* model = model_cast<ModelMeaslesMixingRiskQuarantine<TSeq>,TSeq>(m);
-    
-    // This will move agents between states
-    model->m_quarantine_process();
-
-    // Updating the list of infectious agents. This is needed
-    // for the transmission dynamics.
-    model->m_update_infectious_list();
-
-    return;
-}
 
 template<typename TSeq>
 inline double ModelMeaslesMixingRiskQuarantine<TSeq>::m_get_risk_period(size_t agent_id)
@@ -28243,7 +28117,7 @@ inline double ModelMeaslesMixingRiskQuarantine<TSeq>::m_get_risk_period(size_t a
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_infectious_list()
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_infectious_list()
 {
 
     // Getting the agents from the model
@@ -28380,7 +28254,7 @@ inline size_t ModelMeaslesMixingRiskQuarantine<TSeq>::sample_infectious_agents(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_susceptible(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_susceptible(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -28449,7 +28323,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_susceptible(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_latent(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_latent(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -28465,7 +28339,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_latent(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_prodromal(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_prodromal(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
     
@@ -28491,7 +28365,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_prodromal(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_rash(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_rash(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -28538,7 +28412,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_rash(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_isolated(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_isolated(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -28581,7 +28455,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_isolated(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_isolated_recovered(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_isolated_recovered(
     Agent<TSeq> * p,
     Model<TSeq> * m
 ) {
@@ -28598,7 +28472,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_isolated_recovered(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_suscep(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_quarantine_suscep(
     Agent<TSeq> * p,
     Model<TSeq> * m
 ) {
@@ -28617,7 +28491,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_suscep(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_latent(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_quarantine_latent(
     Agent<TSeq> * p,
     Model<TSeq> * m
 ) {
@@ -28650,7 +28524,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_latent(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_prodromal(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_quarantine_prodromal(
     Agent<TSeq> * p,
     Model<TSeq> * m
 ) {
@@ -28683,7 +28557,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_prodroma
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_recovered(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_quarantine_recovered(
     Agent<TSeq> * p,
     Model<TSeq> * m
 ) {
@@ -28702,7 +28576,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_recovere
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_hospitalized(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_hospitalized(
     Agent<TSeq> * p,
     Model<TSeq> * m
 ) {
@@ -28725,24 +28599,26 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_add_contact_tracing(size_t
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_quarantine_process(Model<TSeq> * m) {
+
+    auto* model = model_cast<ModelMeaslesMixingRiskQuarantine<TSeq>,TSeq>(m);
 
     // If no agents triggered contact tracing, then we skip
-    if (agents_triggered_contact_tracing_size == 0u)
+    if (model->agents_triggered_contact_tracing_size == 0u)
         return;
 
     // We increase the number of quarantines
-    days_quarantine_triggered.push_back(this->today());
+    model->days_quarantine_triggered.push_back(m->today());
 
     // This vector indicates whether an agent can be quarantined
     // (i.e., is not already in quarantine or isolation)
     std::vector< bool > can_quarantine(
-        this->size(), false
+        m->size(), false
     );
 
     // Assigning all individuals who are not currently in quarantine/isolation
     // a low level
-    for (auto & agent: this->get_agents())
+    for (auto & agent: m->get_agents())
     {
 
         auto state = agent.get_state();
@@ -28754,7 +28630,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
             (state == RASH)
         )
         {
-            quarantine_risk_level[agent.get_id()] = RISK_LOW;
+            model->quarantine_risk_level[agent.get_id()] = RISK_LOW;
             can_quarantine[agent.get_id()] = true;
         }
 
@@ -28765,12 +28641,12 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
     #endif
 
     // Checking the risk levels
-    double param_days_prior = Model<TSeq>::par("Contact tracing days prior");
-    for (size_t i = 0u; i < agents_triggered_contact_tracing_size; ++i)
+    double param_days_prior = m->par("Contact tracing days prior");
+    for (size_t i = 0u; i < model->agents_triggered_contact_tracing_size; ++i)
     {
 
-        size_t agent_i_idx = agents_triggered_contact_tracing[i];
-        auto & agent_i = Model<TSeq>::get_agent(agent_i_idx);
+        size_t agent_i_idx = model->agents_triggered_contact_tracing[i];
+        auto & agent_i = m->get_agent(agent_i_idx);
 
         // (A) Checking entity first
         // It doesn't matter if the agent doesn't have a tool; we will
@@ -28781,7 +28657,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
             {
 
                 #ifdef EPI_DEBUG
-                auto & agent_j = Model<TSeq>::get_agent(agent_j_idx);
+                auto & agent_j = m->get_agent(agent_j_idx);
                 if (
                     agent_j.get_entity(0u, *this).get_id() !=
                     agent_i.get_entity(0u, *this).get_id()
@@ -28794,14 +28670,15 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
 
                 // Only if not already checked we set to high risk
                 if (can_quarantine[agent_j_idx])
-                    quarantine_risk_level[agent_j_idx] = RISK_HIGH;
+                    model->quarantine_risk_level[agent_j_idx] = RISK_HIGH;
 
 
             }
         }
 
         // (B) Checking the contacts
-        size_t n_contacts = this->contact_tracing->get_n_contacts(agent_i_idx);
+        auto & ct = model->get_contact_tracing();
+        size_t n_contacts = ct.get_n_contacts(agent_i_idx);
         if (n_contacts > EPI_MAX_TRACKING)
             n_contacts = EPI_MAX_TRACKING;
 
@@ -28809,7 +28686,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
         {
 
             // Getting the location in the matrix
-            auto [contact_id, contact_date] = this->contact_tracing->get_contact(
+            auto [contact_id, contact_date] = ct.get_contact(
                 agent_i_idx, contact_j_idx
             );
 
@@ -28818,16 +28695,13 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
                 continue;
 
             // Will we detect the contact?
-            if (
-                this->runif() >
-                Model<TSeq>::par("Contact tracing success rate")
-            )
+            if (m->runif() > m->par("Contact tracing success rate"))
                 continue;
 
             // How many days since they contacted relative to the rash onset?
             // (recall that, in this model, the rash period is not infectious)
             double days_since_contact =
-                static_cast<double>(this->day_rash_onset[agent_i_idx]) -
+                static_cast<double>(model->day_rash_onset[agent_i_idx]) -
                 static_cast<double>(contact_date);
 
             // If the contact is outside of the tracing window, we skip it
@@ -28840,15 +28714,15 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
             #endif
 
             // Setting the risk level to medium if not already high
-            if (quarantine_risk_level[contact_id] < RISK_HIGH)
-                quarantine_risk_level[contact_id] = RISK_MEDIUM;
+            if (model->quarantine_risk_level[contact_id] < RISK_HIGH)
+                model->quarantine_risk_level[contact_id] = RISK_MEDIUM;
             
         }
 
     }
 
     // Proceeding to quarantine/isolating agents
-    for (auto & agent: this->get_agents())
+    for (auto & agent: m->get_agents())
     {
 
         // Only if not already checked
@@ -28859,11 +28733,11 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
         if (agent.get_n_tools() != 0u)
             continue;
 
-        if (quarantine_willingness[agent.get_id()] == false)
+        if (model->quarantine_willingness[agent.get_id()] == false)
             continue;
 
         // Setting the day flagged to today
-        day_flagged[agent.get_id()] = this->today();
+        model->day_flagged[agent.get_id()] = m->today();
 
         auto state = agent.get_state();
         if (state == SUSCEPTIBLE)
@@ -28874,7 +28748,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
             agent.change_state(*this, QUARANTINED_PRODROMAL);
         else if (state == RASH)
         {
-            if (isolation_willingness[agent.get_id()])
+            if (model->isolation_willingness[agent.get_id()])
                 agent.change_state(*this, ISOLATED);
         }
         else
@@ -28896,7 +28770,8 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
         auto & agent_i = Model<TSeq>::get_agent(agent_i_idx);
 
         // We also check who are the contacted agents
-        size_t n_contacts = this->contact_tracing->get_n_contacts(agent_i_idx);
+        auto & ct = model->get_contact_tracing();
+        size_t n_contacts = ct.get_n_contacts(agent_i_idx);
         if (n_contacts >= EPI_MAX_TRACKING)
             n_contacts = EPI_MAX_TRACKING;
 
@@ -28904,7 +28779,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
         {
 
             // Getting the location in the matrix
-            auto [contact_id, contact_date] = this->contact_tracing->get_contact(
+            auto [contact_id, contact_date] = ct.get_contact(
                 agent_i_idx, contact_j_idx
             );
 
@@ -28947,7 +28822,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
             if (agent_i.get_n_tools() != 0u)
                 continue;
 
-            if (quarantine_risk_level[agent_i_idx] != RISK_HIGH)
+            if (model->quarantine_risk_level[agent_i_idx] != RISK_HIGH)
                 throw std::logic_error(
                     "An agent in a group that triggered contact tracing is not in RISK_HIGH."
                 );
@@ -28975,7 +28850,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
                 continue;
         }
 
-        if (quarantine_risk_level[agent_i_idx] != RISK_MEDIUM)
+        if (model->quarantine_risk_level[agent_i_idx] != RISK_MEDIUM)
             throw std::logic_error(
                 "An agent who was contacted by an infectious agent is not in at least RISK_MEDIUM."
             );
@@ -28983,15 +28858,12 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
 
     // Tabulating the number of agents per group
     std::vector< size_t > n_agents_per_group(Model<TSeq>::entities.size(), 0u);
-    for (auto i: quarantine_risk_level)
+    for (auto i: model->quarantine_risk_level)
         n_agents_per_group[i]++;
 
     #endif
     
-    // Applying the changes and resetting the number of agents
-    // who triggered contact tracing
-    Model<TSeq>::events_run();
-    agents_triggered_contact_tracing_size = 0u; 
+    model->agents_triggered_contact_tracing_size = 0u; 
 
     return;
 }
@@ -29057,21 +28929,25 @@ inline ModelMeaslesMixingRiskQuarantine<TSeq>::ModelMeaslesMixingRiskQuarantine(
     this->add_param(vax_efficacy, "Vax efficacy");
     
     // state
-    this->add_state("Susceptible", m_update_susceptible);
-    this->add_state("Latent", m_update_latent);
-    this->add_state("Prodromal", m_update_prodromal);
-    this->add_state("Rash", m_update_rash);
-    this->add_state("Isolated", m_update_isolated);
-    this->add_state("Isolated Recovered", m_update_isolated_recovered);
-    this->add_state("Quarantined Latent", m_update_quarantine_latent);
-    this->add_state("Quarantined Susceptible", m_update_quarantine_suscep);
-    this->add_state("Quarantined Prodromal", m_update_quarantine_prodromal);
-    this->add_state("Quarantined Recovered", m_update_quarantine_recovered);
-    this->add_state("Hospitalized", m_update_hospitalized);
+    this->add_state("Susceptible", _update_susceptible);
+    this->add_state("Latent", _update_latent);
+    this->add_state("Prodromal", _update_prodromal);
+    this->add_state("Rash", _update_rash);
+    this->add_state("Isolated", _update_isolated);
+    this->add_state("Isolated Recovered", _update_isolated_recovered);
+    this->add_state("Quarantined Latent", _update_quarantine_latent);
+    this->add_state("Quarantined Susceptible", _update_quarantine_suscep);
+    this->add_state("Quarantined Prodromal", _update_quarantine_prodromal);
+    this->add_state("Quarantined Recovered", _update_quarantine_recovered);
+    this->add_state("Hospitalized", _update_hospitalized);
     this->add_state("Recovered");
 
     // Global function
-    this->add_globalevent(this->m_update_model, "Update infected individuals");
+    this->add_globalevent(
+        this->_quarantine_process,
+        "Update infected individuals"
+    );
+
     this->queuing_off();
 
     // Preparing the virus -------------------------------------------
@@ -29166,7 +29042,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::reset()
 
     }
 
-    this->m_update_infectious_list();
+    this->_update_infectious_list();
 
     // Setting up the quarantine parameters
     quarantine_willingness.resize(this->size(), false);
@@ -29217,6 +29093,13 @@ inline ModelMeaslesMixingRiskQuarantine<TSeq> & ModelMeaslesMixingRiskQuarantine
 
     return *this;
 
+}
+
+template<typename TSeq>
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::next()
+{
+    this->_update_infectious_list();
+    Model<TSeq>::next();
 }
 
 #endif

--- a/epiworld.hpp
+++ b/epiworld.hpp
@@ -25462,7 +25462,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::_update_susceptible(
     // class
     auto * m_down = model_cast<ModelSEIRMixingQuarantine<TSeq>, TSeq>(m);
 
-    size_t ndraws = m_down->sample_agents(p, m_down->sampled_agents);
+    size_t ndraws = m_down->_sample_agents(p, m_down->sampled_agents);
 
     #ifdef EPI_DEBUG
     m_down->sampled_sizes.push_back(static_cast<int>(ndraws));
@@ -25805,7 +25805,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::_quarantine_process(Model<TSeq> * m
         // Getting the number of contacts, if it is greater
         // than the maximum, it means that we overflowed, so
         // we will only quarantine the first EPI_MAX_TRACKING
-        auto ct = m->get_contact_tracing();
+        auto & ct = m->get_contact_tracing();
         size_t n_contacts = ct.get_n_contacts(agent_i);
         if (n_contacts >= EPI_MAX_TRACKING)
             n_contacts = EPI_MAX_TRACKING;
@@ -28653,14 +28653,14 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_quarantine_process(Model<TS
         // check that later
         if (agent_i.get_n_entities() != 0u)
         {
-            for (size_t agent_j_idx: agent_i.get_entity(0, *this))
+            for (size_t agent_j_idx: agent_i.get_entity(0, *m))
             {
 
                 #ifdef EPI_DEBUG
                 auto & agent_j = m->get_agent(agent_j_idx);
                 if (
-                    agent_j.get_entity(0u, *this).get_id() !=
-                    agent_i.get_entity(0u, *this).get_id()
+                    agent_j.get_entity(0u, *m).get_id() !=
+                    agent_i.get_entity(0u, *m).get_id()
                 )
                     throw std::logic_error(
                         "An agent in a group has a different group id."
@@ -28741,15 +28741,15 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_quarantine_process(Model<TS
 
         auto state = agent.get_state();
         if (state == SUSCEPTIBLE)
-            agent.change_state(*this, QUARANTINED_SUSCEPTIBLE);
+            agent.change_state(*m, QUARANTINED_SUSCEPTIBLE);
         else if (state == LATENT)
-            agent.change_state(*this, QUARANTINED_LATENT);
+            agent.change_state(*m, QUARANTINED_LATENT);
         else if (state == PRODROMAL)
-            agent.change_state(*this, QUARANTINED_PRODROMAL);
+            agent.change_state(*m, QUARANTINED_PRODROMAL);
         else if (state == RASH)
         {
             if (model->isolation_willingness[agent.get_id()])
-                agent.change_state(*this, ISOLATED);
+                agent.change_state(*m, ISOLATED);
         }
         else
             throw std::logic_error(
@@ -28762,12 +28762,12 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_quarantine_process(Model<TS
     // quarantined should be in RISK_HIGH
     std::set< size_t > groups_ids;
     std::set< size_t > contacted_agents;
-    for (size_t i = 0u; i < agents_triggered_contact_tracing_size; ++i)
+    for (size_t i = 0u; i < model->agents_triggered_contact_tracing_size; ++i)
     {
 
-        auto agent_i_idx = agents_triggered_contact_tracing[i];
+        auto agent_i_idx = model->agents_triggered_contact_tracing[i];
 
-        auto & agent_i = Model<TSeq>::get_agent(agent_i_idx);
+        auto & agent_i = m->get_agent(agent_i_idx);
 
         // We also check who are the contacted agents
         auto & ct = model->get_contact_tracing();
@@ -28794,7 +28794,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_quarantine_process(Model<TS
         if (agent_i.get_n_entities() == 0u)
             continue;
 
-        groups_ids.insert(agent_i.get_entity(0u, *this).get_id());
+        groups_ids.insert(agent_i.get_entity(0u, *m).get_id());
         
     }
 
@@ -28857,7 +28857,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_quarantine_process(Model<TS
     }
 
     // Tabulating the number of agents per group
-    std::vector< size_t > n_agents_per_group(Model<TSeq>::entities.size(), 0u);
+    std::vector< size_t > n_agents_per_group(m->get_entities().size(), 0u);
     for (auto i: model->quarantine_risk_level)
         n_agents_per_group[i]++;
 

--- a/include/epiworld/models/measlesmixingriskquarantine.hpp
+++ b/include/epiworld/models/measlesmixingriskquarantine.hpp
@@ -937,12 +937,12 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_quarantine_process(Model<TS
     // quarantined should be in RISK_HIGH
     std::set< size_t > groups_ids;
     std::set< size_t > contacted_agents;
-    for (size_t i = 0u; i < agents_triggered_contact_tracing_size; ++i)
+    for (size_t i = 0u; i < model->agents_triggered_contact_tracing_size; ++i)
     {
 
-        auto agent_i_idx = agents_triggered_contact_tracing[i];
+        auto agent_i_idx = model->agents_triggered_contact_tracing[i];
 
-        auto & agent_i = Model<TSeq>::get_agent(agent_i_idx);
+        auto & agent_i = m->get_agent(agent_i_idx);
 
         // We also check who are the contacted agents
         auto & ct = model->get_contact_tracing();
@@ -1032,7 +1032,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_quarantine_process(Model<TS
     }
 
     // Tabulating the number of agents per group
-    std::vector< size_t > n_agents_per_group(Model<TSeq>::entities.size(), 0u);
+    std::vector< size_t > n_agents_per_group(m->get_entities().size(), 0u);
     for (auto i: model->quarantine_risk_level)
         n_agents_per_group[i]++;
 

--- a/include/epiworld/models/measlesmixingriskquarantine.hpp
+++ b/include/epiworld/models/measlesmixingriskquarantine.hpp
@@ -51,7 +51,7 @@ private:
     double m_get_risk_period(size_t agent_id);
 
     // Update the list of infectious agents
-    void m_update_infectious_list();
+    void _update_infectious_list();
 
     // Vector to hold sampled agents temporarily
     std::vector< size_t > sampled_agents;
@@ -77,17 +77,17 @@ private:
     #endif
 
     // Update functions
-    static void m_update_susceptible(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_latent(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_prodromal(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_rash(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_isolated(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_isolated_recovered(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_quarantine_suscep(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_quarantine_latent(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_quarantine_prodromal(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_quarantine_recovered(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_hospitalized(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_susceptible(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_latent(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_prodromal(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_rash(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_isolated(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_isolated_recovered(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_quarantine_suscep(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_quarantine_latent(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_quarantine_prodromal(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_quarantine_recovered(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_hospitalized(Agent<TSeq> * p, Model<TSeq> * m);
 
     // Data about the quarantine process
     std::vector< bool > quarantine_willingness; ///< Indicator for quarantine willingness
@@ -104,9 +104,7 @@ private:
     
     std::vector< int > quarantine_risk_level; ///< Risk level assigned to each agent (0=low, 1=medium, 2=high)
     
-    void m_quarantine_process(); ///< Overall quarantine process
-
-    static void m_update_model(Model<TSeq> * m);
+    static void _quarantine_process(Model<TSeq> * m); ///< Overall quarantine process
 
     std::vector< size_t > days_quarantine_triggered; ///< Days when quarantine was triggered
 
@@ -267,26 +265,11 @@ public:
         return days_quarantine_triggered;
     };
 
+    void next() override;
+
 };
 
 // Implementation starts here
-
-template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_model(
-    Model<TSeq> * m
-)
-{
-    auto* model = model_cast<ModelMeaslesMixingRiskQuarantine<TSeq>,TSeq>(m);
-    
-    // This will move agents between states
-    model->m_quarantine_process();
-
-    // Updating the list of infectious agents. This is needed
-    // for the transmission dynamics.
-    model->m_update_infectious_list();
-
-    return;
-}
 
 template<typename TSeq>
 inline double ModelMeaslesMixingRiskQuarantine<TSeq>::m_get_risk_period(size_t agent_id)
@@ -309,7 +292,7 @@ inline double ModelMeaslesMixingRiskQuarantine<TSeq>::m_get_risk_period(size_t a
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_infectious_list()
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_infectious_list()
 {
 
     // Getting the agents from the model
@@ -446,7 +429,7 @@ inline size_t ModelMeaslesMixingRiskQuarantine<TSeq>::sample_infectious_agents(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_susceptible(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_susceptible(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -515,7 +498,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_susceptible(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_latent(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_latent(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -531,7 +514,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_latent(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_prodromal(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_prodromal(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
     
@@ -557,7 +540,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_prodromal(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_rash(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_rash(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -604,7 +587,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_rash(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_isolated(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_isolated(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -647,7 +630,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_isolated(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_isolated_recovered(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_isolated_recovered(
     Agent<TSeq> * p,
     Model<TSeq> * m
 ) {
@@ -664,7 +647,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_isolated_recovered(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_suscep(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_quarantine_suscep(
     Agent<TSeq> * p,
     Model<TSeq> * m
 ) {
@@ -683,7 +666,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_suscep(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_latent(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_quarantine_latent(
     Agent<TSeq> * p,
     Model<TSeq> * m
 ) {
@@ -716,7 +699,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_latent(
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_prodromal(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_quarantine_prodromal(
     Agent<TSeq> * p,
     Model<TSeq> * m
 ) {
@@ -749,7 +732,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_prodroma
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_recovered(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_quarantine_recovered(
     Agent<TSeq> * p,
     Model<TSeq> * m
 ) {
@@ -768,7 +751,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_quarantine_recovere
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_update_hospitalized(
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_update_hospitalized(
     Agent<TSeq> * p,
     Model<TSeq> * m
 ) {
@@ -791,24 +774,26 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_add_contact_tracing(size_t
 }
 
 template<typename TSeq>
-inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::_quarantine_process(Model<TSeq> * m) {
+
+    auto* model = model_cast<ModelMeaslesMixingRiskQuarantine<TSeq>,TSeq>(m);
 
     // If no agents triggered contact tracing, then we skip
-    if (agents_triggered_contact_tracing_size == 0u)
+    if (model->agents_triggered_contact_tracing_size == 0u)
         return;
 
     // We increase the number of quarantines
-    days_quarantine_triggered.push_back(this->today());
+    model->days_quarantine_triggered.push_back(m->today());
 
     // This vector indicates whether an agent can be quarantined
     // (i.e., is not already in quarantine or isolation)
     std::vector< bool > can_quarantine(
-        this->size(), false
+        m->size(), false
     );
 
     // Assigning all individuals who are not currently in quarantine/isolation
     // a low level
-    for (auto & agent: this->get_agents())
+    for (auto & agent: m->get_agents())
     {
 
         auto state = agent.get_state();
@@ -820,7 +805,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
             (state == RASH)
         )
         {
-            quarantine_risk_level[agent.get_id()] = RISK_LOW;
+            model->quarantine_risk_level[agent.get_id()] = RISK_LOW;
             can_quarantine[agent.get_id()] = true;
         }
 
@@ -831,26 +816,26 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
     #endif
 
     // Checking the risk levels
-    double param_days_prior = Model<TSeq>::par("Contact tracing days prior");
-    for (size_t i = 0u; i < agents_triggered_contact_tracing_size; ++i)
+    double param_days_prior = m->par("Contact tracing days prior");
+    for (size_t i = 0u; i < model->agents_triggered_contact_tracing_size; ++i)
     {
 
-        size_t agent_i_idx = agents_triggered_contact_tracing[i];
-        auto & agent_i = Model<TSeq>::get_agent(agent_i_idx);
+        size_t agent_i_idx = model->agents_triggered_contact_tracing[i];
+        auto & agent_i = m->get_agent(agent_i_idx);
 
         // (A) Checking entity first
         // It doesn't matter if the agent doesn't have a tool; we will
         // check that later
         if (agent_i.get_n_entities() != 0u)
         {
-            for (size_t agent_j_idx: agent_i.get_entity(0, *this))
+            for (size_t agent_j_idx: agent_i.get_entity(0, *m))
             {
 
                 #ifdef EPI_DEBUG
-                auto & agent_j = Model<TSeq>::get_agent(agent_j_idx);
+                auto & agent_j = m->get_agent(agent_j_idx);
                 if (
-                    agent_j.get_entity(0u, *this).get_id() !=
-                    agent_i.get_entity(0u, *this).get_id()
+                    agent_j.get_entity(0u, *m).get_id() !=
+                    agent_i.get_entity(0u, *m).get_id()
                 )
                     throw std::logic_error(
                         "An agent in a group has a different group id."
@@ -860,14 +845,15 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
 
                 // Only if not already checked we set to high risk
                 if (can_quarantine[agent_j_idx])
-                    quarantine_risk_level[agent_j_idx] = RISK_HIGH;
+                    model->quarantine_risk_level[agent_j_idx] = RISK_HIGH;
 
 
             }
         }
 
         // (B) Checking the contacts
-        size_t n_contacts = this->contact_tracing->get_n_contacts(agent_i_idx);
+        auto & ct = model->get_contact_tracing();
+        size_t n_contacts = ct.get_n_contacts(agent_i_idx);
         if (n_contacts > EPI_MAX_TRACKING)
             n_contacts = EPI_MAX_TRACKING;
 
@@ -875,7 +861,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
         {
 
             // Getting the location in the matrix
-            auto [contact_id, contact_date] = this->contact_tracing->get_contact(
+            auto [contact_id, contact_date] = ct.get_contact(
                 agent_i_idx, contact_j_idx
             );
 
@@ -884,16 +870,13 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
                 continue;
 
             // Will we detect the contact?
-            if (
-                this->runif() >
-                Model<TSeq>::par("Contact tracing success rate")
-            )
+            if (m->runif() > m->par("Contact tracing success rate"))
                 continue;
 
             // How many days since they contacted relative to the rash onset?
             // (recall that, in this model, the rash period is not infectious)
             double days_since_contact =
-                static_cast<double>(this->day_rash_onset[agent_i_idx]) -
+                static_cast<double>(model->day_rash_onset[agent_i_idx]) -
                 static_cast<double>(contact_date);
 
             // If the contact is outside of the tracing window, we skip it
@@ -906,15 +889,15 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
             #endif
 
             // Setting the risk level to medium if not already high
-            if (quarantine_risk_level[contact_id] < RISK_HIGH)
-                quarantine_risk_level[contact_id] = RISK_MEDIUM;
+            if (model->quarantine_risk_level[contact_id] < RISK_HIGH)
+                model->quarantine_risk_level[contact_id] = RISK_MEDIUM;
             
         }
 
     }
 
     // Proceeding to quarantine/isolating agents
-    for (auto & agent: this->get_agents())
+    for (auto & agent: m->get_agents())
     {
 
         // Only if not already checked
@@ -925,23 +908,23 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
         if (agent.get_n_tools() != 0u)
             continue;
 
-        if (quarantine_willingness[agent.get_id()] == false)
+        if (model->quarantine_willingness[agent.get_id()] == false)
             continue;
 
         // Setting the day flagged to today
-        day_flagged[agent.get_id()] = this->today();
+        model->day_flagged[agent.get_id()] = m->today();
 
         auto state = agent.get_state();
         if (state == SUSCEPTIBLE)
-            agent.change_state(*this, QUARANTINED_SUSCEPTIBLE);
+            agent.change_state(*m, QUARANTINED_SUSCEPTIBLE);
         else if (state == LATENT)
-            agent.change_state(*this, QUARANTINED_LATENT);
+            agent.change_state(*m, QUARANTINED_LATENT);
         else if (state == PRODROMAL)
-            agent.change_state(*this, QUARANTINED_PRODROMAL);
+            agent.change_state(*m, QUARANTINED_PRODROMAL);
         else if (state == RASH)
         {
-            if (isolation_willingness[agent.get_id()])
-                agent.change_state(*this, ISOLATED);
+            if (model->isolation_willingness[agent.get_id()])
+                agent.change_state(*m, ISOLATED);
         }
         else
             throw std::logic_error(
@@ -962,7 +945,8 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
         auto & agent_i = Model<TSeq>::get_agent(agent_i_idx);
 
         // We also check who are the contacted agents
-        size_t n_contacts = this->contact_tracing->get_n_contacts(agent_i_idx);
+        auto & ct = model->get_contact_tracing();
+        size_t n_contacts = ct.get_n_contacts(agent_i_idx);
         if (n_contacts >= EPI_MAX_TRACKING)
             n_contacts = EPI_MAX_TRACKING;
 
@@ -970,7 +954,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
         {
 
             // Getting the location in the matrix
-            auto [contact_id, contact_date] = this->contact_tracing->get_contact(
+            auto [contact_id, contact_date] = ct.get_contact(
                 agent_i_idx, contact_j_idx
             );
 
@@ -985,7 +969,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
         if (agent_i.get_n_entities() == 0u)
             continue;
 
-        groups_ids.insert(agent_i.get_entity(0u, *this).get_id());
+        groups_ids.insert(agent_i.get_entity(0u, *m).get_id());
         
     }
 
@@ -1013,7 +997,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
             if (agent_i.get_n_tools() != 0u)
                 continue;
 
-            if (quarantine_risk_level[agent_i_idx] != RISK_HIGH)
+            if (model->quarantine_risk_level[agent_i_idx] != RISK_HIGH)
                 throw std::logic_error(
                     "An agent in a group that triggered contact tracing is not in RISK_HIGH."
                 );
@@ -1041,7 +1025,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
                 continue;
         }
 
-        if (quarantine_risk_level[agent_i_idx] != RISK_MEDIUM)
+        if (model->quarantine_risk_level[agent_i_idx] != RISK_MEDIUM)
             throw std::logic_error(
                 "An agent who was contacted by an infectious agent is not in at least RISK_MEDIUM."
             );
@@ -1049,15 +1033,12 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::m_quarantine_process() {
 
     // Tabulating the number of agents per group
     std::vector< size_t > n_agents_per_group(Model<TSeq>::entities.size(), 0u);
-    for (auto i: quarantine_risk_level)
+    for (auto i: model->quarantine_risk_level)
         n_agents_per_group[i]++;
 
     #endif
     
-    // Applying the changes and resetting the number of agents
-    // who triggered contact tracing
-    Model<TSeq>::events_run();
-    agents_triggered_contact_tracing_size = 0u; 
+    model->agents_triggered_contact_tracing_size = 0u; 
 
     return;
 }
@@ -1123,21 +1104,25 @@ inline ModelMeaslesMixingRiskQuarantine<TSeq>::ModelMeaslesMixingRiskQuarantine(
     this->add_param(vax_efficacy, "Vax efficacy");
     
     // state
-    this->add_state("Susceptible", m_update_susceptible);
-    this->add_state("Latent", m_update_latent);
-    this->add_state("Prodromal", m_update_prodromal);
-    this->add_state("Rash", m_update_rash);
-    this->add_state("Isolated", m_update_isolated);
-    this->add_state("Isolated Recovered", m_update_isolated_recovered);
-    this->add_state("Quarantined Latent", m_update_quarantine_latent);
-    this->add_state("Quarantined Susceptible", m_update_quarantine_suscep);
-    this->add_state("Quarantined Prodromal", m_update_quarantine_prodromal);
-    this->add_state("Quarantined Recovered", m_update_quarantine_recovered);
-    this->add_state("Hospitalized", m_update_hospitalized);
+    this->add_state("Susceptible", _update_susceptible);
+    this->add_state("Latent", _update_latent);
+    this->add_state("Prodromal", _update_prodromal);
+    this->add_state("Rash", _update_rash);
+    this->add_state("Isolated", _update_isolated);
+    this->add_state("Isolated Recovered", _update_isolated_recovered);
+    this->add_state("Quarantined Latent", _update_quarantine_latent);
+    this->add_state("Quarantined Susceptible", _update_quarantine_suscep);
+    this->add_state("Quarantined Prodromal", _update_quarantine_prodromal);
+    this->add_state("Quarantined Recovered", _update_quarantine_recovered);
+    this->add_state("Hospitalized", _update_hospitalized);
     this->add_state("Recovered");
 
     // Global function
-    this->add_globalevent(this->m_update_model, "Update infected individuals");
+    this->add_globalevent(
+        this->_quarantine_process,
+        "Update infected individuals"
+    );
+
     this->queuing_off();
 
     // Preparing the virus -------------------------------------------
@@ -1232,7 +1217,7 @@ inline void ModelMeaslesMixingRiskQuarantine<TSeq>::reset()
 
     }
 
-    this->m_update_infectious_list();
+    this->_update_infectious_list();
 
     // Setting up the quarantine parameters
     quarantine_willingness.resize(this->size(), false);
@@ -1283,6 +1268,13 @@ inline ModelMeaslesMixingRiskQuarantine<TSeq> & ModelMeaslesMixingRiskQuarantine
 
     return *this;
 
+}
+
+template<typename TSeq>
+inline void ModelMeaslesMixingRiskQuarantine<TSeq>::next()
+{
+    this->_update_infectious_list();
+    Model<TSeq>::next();
 }
 
 #endif

--- a/include/epiworld/models/seirmixingquarantine.hpp
+++ b/include/epiworld/models/seirmixingquarantine.hpp
@@ -790,7 +790,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::_quarantine_process(Model<TSeq> * m
         // Getting the number of contacts, if it is greater
         // than the maximum, it means that we overflowed, so
         // we will only quarantine the first EPI_MAX_TRACKING
-        auto ct = m->get_contact_tracing();
+        auto & ct = m->get_contact_tracing();
         size_t n_contacts = ct.get_n_contacts(agent_i);
         if (n_contacts >= EPI_MAX_TRACKING)
             n_contacts = EPI_MAX_TRACKING;

--- a/include/epiworld/models/seirmixingquarantine.hpp
+++ b/include/epiworld/models/seirmixingquarantine.hpp
@@ -54,9 +54,9 @@ private:
     // Where the agents start in the `infected` vector
     std::vector< size_t > entity_indices;
 
-    void m_update_infected_list();
+    void _update_infected_list();
     std::vector< size_t > sampled_agents;
-    size_t sample_agents(
+    size_t _sample_agents(
         Agent<TSeq> * agent,
         std::vector< size_t > & sampled_agents
         );
@@ -68,14 +68,14 @@ private:
     #endif
 
     // Update functions
-    static void m_update_susceptible(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_exposed(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_infected(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_isolated(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_quarantine_suscep(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_quarantine_exposed(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_hospitalized(Agent<TSeq> * p, Model<TSeq> * m);
-    static void m_update_isolated_recovered(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_susceptible(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_exposed(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_infected(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_isolated(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_quarantine_suscep(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_quarantine_exposed(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_hospitalized(Agent<TSeq> * p, Model<TSeq> * m);
+    static void _update_isolated_recovered(Agent<TSeq> * p, Model<TSeq> * m);
 
     // Data about the quarantine process
     std::vector< bool > quarantine_willingness; ///< Indicator
@@ -85,8 +85,7 @@ private:
     std::vector< int > day_onset; ///< Day of onset of the disease
     std::vector< int > day_exposed; ///< Day of exposure
 
-    void m_quarantine_process();
-    static void m_update_model(Model<TSeq> * m);
+    static void _quarantine_process(Model<TSeq> * m);
 
 public:
 
@@ -105,51 +104,6 @@ public:
     static const size_t QUARANTINE_PROCESS_DONE     = 2u;
 
     ModelSEIRMixingQuarantine() {};
-
-    /**
-     * @brief Constructs a ModelSEIRMixingQuarantine object.
-     *
-     * @param model A reference to an existing ModelSEIRMixingQuarantine object.
-     * @param vname The name of the ModelSEIRMixingQuarantine object.
-     * @param n The number of entities in the model.
-     * @param prevalence The initial prevalence of the disease in the model.
-     * @param contact_rate The contact rate between entities in the model.
-     * @param transmission_rate The transmission rate of the disease in the model.
-     * @param avg_incubation_days The average incubation period of the disease in the model.
-     * @param recovery_rate The recovery rate of the disease in the model.
-     * @param contact_matrix The contact matrix between entities in the model. Specified in
-     * column-major order.
-     * @param hospitalization_rate The rate at which infected individuals are hospitalized.
-     * @param hospitalization_period The average duration of hospitalization in days.
-     * @param days_undetected The average number of days an infected individual remains undetected.
-     * @param quarantine_period The duration of quarantine in days for exposed contacts.
-     * @param quarantine_willingness The proportion of individuals willing to comply with quarantine measures.
-     * @param isolation_willingness The proportion of individuals willing to self-isolate when detected.
-     * @param isolation_period The duration of isolation in days for detected infected individuals.
-     * @param contact_tracing_success_rate The probability of successfully identifying and tracing contacts (default: 1.0).
-     * @param contact_tracing_days_prior The number of days prior to detection for which contacts are traced (default: 4).
-     */
-    ModelSEIRMixingQuarantine(
-        ModelSEIRMixingQuarantine<TSeq> & model,
-        const std::string & vname,
-        epiworld_fast_uint n,
-        epiworld_double prevalence,
-        epiworld_double contact_rate,
-        epiworld_double transmission_rate,
-        epiworld_double avg_incubation_days,
-        epiworld_double recovery_rate,
-        std::vector< double > contact_matrix,
-        epiworld_double hospitalization_rate,
-        epiworld_double hospitalization_period,
-        // Policy parameters
-        epiworld_double days_undetected,
-        epiworld_fast_int quarantine_period,
-        epiworld_double quarantine_willingness,
-        epiworld_double isolation_willingness,
-        epiworld_fast_int isolation_period,
-        epiworld_double contact_tracing_success_rate = 1.0,
-        epiworld_fast_uint contact_tracing_days_prior = 4u
-    );
 
     /**
      * @brief Constructs a ModelSEIRMixingQuarantine object.
@@ -262,20 +216,12 @@ public:
         return isolation_willingness;
     };
 
+    void next() override;
+
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_model(Model<TSeq> * m)
-{
-    auto * model = model_cast<ModelSEIRMixingQuarantine<TSeq>, TSeq>(m);
-    model->m_quarantine_process();
-    model->events_run();
-    model->m_update_infected_list();
-    return;
-}
-
-template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_infected_list()
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_infected_list()
 {
 
     auto & agents = this->get_agents();
@@ -333,7 +279,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_infected_list()
 }
 
 template<typename TSeq>
-inline size_t ModelSEIRMixingQuarantine<TSeq>::sample_agents(
+inline size_t ModelSEIRMixingQuarantine<TSeq>::_sample_agents(
     Agent<TSeq> * agent,
     std::vector< size_t > & sampled_agents
     )
@@ -459,25 +405,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::reset()
 
     }
 
-    // // Adjusting contact rate
-    // adjusted_contact_rate.clear();
-    // adjusted_contact_rate.resize(this->entities.size(), 0.0);
-
-    // for (size_t i = 0u; i < this->entities.size(); ++i)
-    // {
-
-    //     adjusted_contact_rate[i] =
-    //         Model<TSeq>::get_param("Contact rate") /
-    //             static_cast< epiworld_double > (this->get_entity(i).size());
-
-
-    //     // Possibly correcting for a small number of agents
-    //     if (adjusted_contact_rate[i] > 1.0)
-    //         adjusted_contact_rate[i] = 1.0;
-
-    // }
-
-    this->m_update_infected_list();
+    this->_update_infected_list();
 
     // Setting up the quarantine parameters
     quarantine_willingness.resize(this->size(), false);
@@ -508,7 +436,7 @@ inline std::unique_ptr<Model<TSeq>> ModelSEIRMixingQuarantine<TSeq>::clone_ptr()
 }
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_susceptible(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_susceptible(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -519,7 +447,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_susceptible(
     // class
     auto * m_down = model_cast<ModelSEIRMixingQuarantine<TSeq>, TSeq>(m);
 
-    size_t ndraws = m_down->sample_agents(p, m_down->sampled_agents);
+    size_t ndraws = m_down->_sample_agents(p, m_down->sampled_agents);
 
     #ifdef EPI_DEBUG
     m_down->sampled_sizes.push_back(static_cast<int>(ndraws));
@@ -575,7 +503,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_susceptible(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_exposed(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_exposed(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -598,7 +526,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_exposed(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_infected(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_infected(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -677,7 +605,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_infected(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_isolated(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_isolated(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -732,7 +660,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_isolated(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_quarantine_suscep(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_quarantine_suscep(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -756,7 +684,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_quarantine_suscep(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_quarantine_exposed(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_quarantine_exposed(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -801,7 +729,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_quarantine_exposed(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_isolated_recovered(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_isolated_recovered(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -825,7 +753,7 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_isolated_recovered(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_update_hospitalized(
+inline void ModelSEIRMixingQuarantine<TSeq>::_update_hospitalized(
     Agent<TSeq> * p, Model<TSeq> * m
 ) {
 
@@ -836,52 +764,56 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_update_hospitalized(
 };
 
 template<typename TSeq>
-inline void ModelSEIRMixingQuarantine<TSeq>::m_quarantine_process() {
+inline void ModelSEIRMixingQuarantine<TSeq>::_quarantine_process(Model<TSeq> * m) {
+
+    auto * model = model_cast<ModelSEIRMixingQuarantine<TSeq>, TSeq>(m);
 
     // Process entity-level quarantine
-    for (size_t agent_i = 0u; agent_i < this->size(); ++agent_i)
+    for (size_t agent_i = 0u; agent_i < m->size(); ++agent_i)
     {
 
         // Checking if the quarantine in the agent was triggered
         // or not
         if (
-            agent_quarantine_triggered[agent_i] !=
+            model->agent_quarantine_triggered[agent_i] !=
             ModelSEIRMixingQuarantine<TSeq>::QUARANTINE_PROCESS_ACTIVE
         )
             continue;
 
-        if (this->par("Quarantine period") < 0)
+        if (m->par("Quarantine period") < 0)
         {
-            agent_quarantine_triggered[agent_i] = QUARANTINE_PROCESS_DONE;
+            model->agent_quarantine_triggered[agent_i] =
+            ModelSEIRMixingQuarantine<TSeq>::QUARANTINE_PROCESS_DONE;
             continue;
         }
 
         // Getting the number of contacts, if it is greater
         // than the maximum, it means that we overflowed, so
         // we will only quarantine the first EPI_MAX_TRACKING
-        size_t n_contacts = this->contact_tracing->get_n_contacts(agent_i);
+        auto ct = m->get_contact_tracing();
+        size_t n_contacts = ct.get_n_contacts(agent_i);
         if (n_contacts >= EPI_MAX_TRACKING)
             n_contacts = EPI_MAX_TRACKING;
 
-        auto success_rate = this->par("Contact tracing success rate");
-        auto days_prior = this->par("Contact tracing days prior");
+        auto success_rate = m->par("Contact tracing success rate");
+        auto days_prior = m->par("Contact tracing days prior");
         for (size_t contact_i = 0u; contact_i < n_contacts; ++contact_i)
         {
 
             // Checking if we will detect the contact
-            if (this->runif() > success_rate)
+            if (m->runif() > success_rate)
                 continue;
 
-            auto [contact_id, contact_date] = this->contact_tracing->get_contact(
+            auto [contact_id, contact_date] = ct.get_contact(
                 agent_i, contact_i
             );
 
             // Skip contacts outside the tracing window
-            if ((static_cast<double>(this->today()) -
+            if ((static_cast<double>(m->today()) -
                 static_cast<double>(contact_date)) > days_prior)
                 continue;
 
-            auto & agent = Model<TSeq>::get_agent(contact_id);
+            auto & agent = m->get_agent(contact_id);
 
             if (agent.get_state() > INFECTED)
                 continue;
@@ -890,24 +822,24 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_quarantine_process() {
             if (agent.get_n_tools() != 0u)
                 continue;
 
-            if (quarantine_willingness[contact_id])
+            if (model->quarantine_willingness[contact_id])
             {
 
                 switch (agent.get_state())
                 {
                     case SUSCEPTIBLE:
-                        agent.change_state(*this, QUARANTINED_SUSCEPTIBLE);
-                        day_flagged[contact_id] = this->today();
+                        agent.change_state(*m, ModelSEIRMixingQuarantine<TSeq>::QUARANTINED_SUSCEPTIBLE);
+                        model->day_flagged[contact_id] = m->today();
                         break;
                     case EXPOSED:
-                        agent.change_state(*this, QUARANTINED_EXPOSED);
-                        day_flagged[contact_id] = this->today();
+                        agent.change_state(*m, ModelSEIRMixingQuarantine<TSeq>::QUARANTINED_EXPOSED);
+                        model->day_flagged[contact_id] = m->today();
                         break;
                     case INFECTED:
-                        if (isolation_willingness[contact_id])
+                        if (model->isolation_willingness[contact_id])
                         {
-                            agent.change_state(*this, ISOLATED);
-                            day_flagged[contact_id] = this->today();
+                            agent.change_state(*m, ModelSEIRMixingQuarantine<TSeq>::ISOLATED);
+                            model->day_flagged[contact_id] = m->today();
                         }
                         break;
                     default:
@@ -920,7 +852,8 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_quarantine_process() {
         }
 
         // Setting the quarantine process off
-        agent_quarantine_triggered[agent_i] = QUARANTINE_PROCESS_DONE;
+        model->agent_quarantine_triggered[agent_i] =
+            ModelSEIRMixingQuarantine<TSeq>::QUARANTINE_PROCESS_DONE;
     }
 
     return;
@@ -950,7 +883,6 @@ inline void ModelSEIRMixingQuarantine<TSeq>::m_quarantine_process() {
  */
 template<typename TSeq>
 inline ModelSEIRMixingQuarantine<TSeq>::ModelSEIRMixingQuarantine(
-    ModelSEIRMixingQuarantine<TSeq> & model,
     const std::string & vname,
     epiworld_fast_uint n,
     epiworld_double prevalence,
@@ -976,117 +908,66 @@ inline ModelSEIRMixingQuarantine<TSeq>::ModelSEIRMixingQuarantine(
     this->contact_matrix = contact_matrix;
 
     // Setting up parameters
-    model.add_param(contact_rate, "Contact rate");
-    model.add_param(transmission_rate, "Prob. Transmission");
-    model.add_param(recovery_rate, "Prob. Recovery");
-    model.add_param(avg_incubation_days, "Avg. Incubation days");
-    model.add_param(hospitalization_rate, "Hospitalization rate");
-    model.add_param(hospitalization_period, "Hospitalization period");
-    model.add_param(days_undetected, "Days undetected");
-    model.add_param(quarantine_period, "Quarantine period");
-    model.add_param(
+    this->add_param(contact_rate, "Contact rate");
+    this->add_param(transmission_rate, "Prob. Transmission");
+    this->add_param(recovery_rate, "Prob. Recovery");
+    this->add_param(avg_incubation_days, "Avg. Incubation days");
+    this->add_param(hospitalization_rate, "Hospitalization rate");
+    this->add_param(hospitalization_period, "Hospitalization period");
+    this->add_param(days_undetected, "Days undetected");
+    this->add_param(quarantine_period, "Quarantine period");
+    this->add_param(
         quarantine_willingness, "Quarantine willingness"
     );
-    model.add_param(
+    this->add_param(
         isolation_willingness, "Isolation willingness"
     );
-    model.add_param(isolation_period, "Isolation period");
-    model.add_param(
+    this->add_param(isolation_period, "Isolation period");
+    this->add_param(
         contact_tracing_success_rate, "Contact tracing success rate"
     );
-    model.add_param(
+    this->add_param(
         contact_tracing_days_prior, "Contact tracing days prior"
     );
 
     // state
-    model.add_state("Susceptible", m_update_susceptible);
-    model.add_state("Exposed", m_update_exposed);
-    model.add_state("Infected", m_update_infected);
-    model.add_state("Isolated", m_update_isolated);
-    model.add_state("Quarantined Susceptible", m_update_quarantine_suscep);
-    model.add_state("Quarantined Exposed", m_update_quarantine_exposed);
-    model.add_state("Isolated Recovered", m_update_isolated_recovered);
-    model.add_state("Hospitalized", m_update_hospitalized);
-    model.add_state("Recovered");
+    this->add_state("Susceptible", _update_susceptible);
+    this->add_state("Exposed", _update_exposed);
+    this->add_state("Infected", _update_infected);
+    this->add_state("Isolated", _update_isolated);
+    this->add_state("Quarantined Susceptible", _update_quarantine_suscep);
+    this->add_state("Quarantined Exposed", _update_quarantine_exposed);
+    this->add_state("Isolated Recovered", _update_isolated_recovered);
+    this->add_state("Hospitalized", _update_hospitalized);
+    this->add_state("Recovered");
 
     // Global function
-    model.add_globalevent(this->m_update_model, "Update infected individuals");
-    model.queuing_off();
+    this->add_globalevent(
+        this->_quarantine_process,
+        "Update infected individuals"
+    );
+
+    this->queuing_off();
 
     // Preparing the virus -------------------------------------------
     Virus<TSeq> virus(vname, prevalence, true);
-    virus.set_state(
-        ModelSEIRMixingQuarantine<TSeq>::EXPOSED,
-        ModelSEIRMixingQuarantine<TSeq>::RECOVERED,
-        ModelSEIRMixingQuarantine<TSeq>::RECOVERED
-        );
+    virus.set_state(EXPOSED, RECOVERED, RECOVERED);
 
     virus.set_prob_infecting("Prob. Transmission");
     virus.set_prob_recovery("Prob. Recovery");
     virus.set_incubation("Avg. Incubation days");
 
-    model.add_virus(virus);
+    this->add_virus(virus);
 
-    model.queuing_off(); // No queuing need
+    this->queuing_off(); // No queuing need
 
     // Enable contact tracing for quarantine process
-    model.contact_tracing_on(EPI_MAX_TRACKING);
+    this->contact_tracing_on(EPI_MAX_TRACKING);
 
     // Adding the empty population
-    model.agents_empty_graph(n);
+    this->agents_empty_graph(n);
 
-    model.set_name("SEIR with Mixing and Quarantine");
-
-    return;
-
-}
-
-template<typename TSeq>
-inline ModelSEIRMixingQuarantine<TSeq>::ModelSEIRMixingQuarantine(
-    const std::string & vname,
-    epiworld_fast_uint n,
-    epiworld_double prevalence,
-    epiworld_double contact_rate,
-    epiworld_double transmission_rate,
-    epiworld_double avg_incubation_days,
-    epiworld_double recovery_rate,
-    std::vector< double > contact_matrix,
-    epiworld_double hospitalization_rate,
-    epiworld_double hospitalization_period,
-    // Policy parameters
-    epiworld_double days_undetected,
-    epiworld_fast_int quarantine_period,
-    epiworld_double quarantine_willingness,
-    epiworld_double isolation_willingness,
-    epiworld_fast_int isolation_period,
-    epiworld_double contact_tracing_success_rate,
-    epiworld_fast_uint contact_tracing_days_prior
-    )
-{
-
-    this->contact_matrix = contact_matrix;
-
-    ModelSEIRMixingQuarantine(
-        *this,
-        vname,
-        n,
-        prevalence,
-        contact_rate,
-        transmission_rate,
-        avg_incubation_days,
-        recovery_rate,
-        contact_matrix,
-        hospitalization_rate,
-        hospitalization_period,
-        // Policy parameters
-        days_undetected,
-        quarantine_period,
-        quarantine_willingness,
-        isolation_willingness,
-        isolation_period,
-        contact_tracing_success_rate,
-        contact_tracing_days_prior
-    );
+    this->set_name("SEIR with Mixing and Quarantine");
 
     return;
 
@@ -1106,5 +987,15 @@ inline ModelSEIRMixingQuarantine<TSeq> & ModelSEIRMixingQuarantine<TSeq>::initia
     return *this;
 
 }
+
+
+template<typename TSeq>
+inline void ModelSEIRMixingQuarantine<TSeq>::next() {
+
+    this->_update_infected_list();
+    Model<TSeq>::next();
+
+}
+
 #undef MM
 #endif


### PR DESCRIPTION
This pull request primarily refactors the `ModelMeaslesMixingRiskQuarantine` class by renaming internal methods and static update functions from the `m_` prefix to an underscore `_` prefix, and by converting some member functions to static methods that now explicitly take a `Model<TSeq>*` parameter. This improves code clarity, consistency, and aligns with common naming conventions for private or internal-use functions. Additionally, the quarantine process logic is updated to consistently use the model pointer, enhancing maintainability and reducing ambiguity in member access.

**Refactoring of Internal and Static Methods:**

- Renamed all internal and static update functions from the `m_` prefix to an underscore `_` prefix (e.g., `m_update_susceptible` → `_update_susceptible`, `m_update_infectious_list` → `_update_infectious_list`) to standardize naming for private/internal methods. [[1]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L54-R54) [[2]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L80-R90) [[3]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L312-R295) [[4]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L449-R432) [[5]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L518-R501) [[6]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L534-R517) [[7]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L560-R543) [[8]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L607-R590) [[9]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L650-R633) [[10]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L667-R650) [[11]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L686-R669) [[12]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L719-R702) [[13]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L752-R735) [[14]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L771-R754)

- Updated the quarantine process function from a member function (`m_quarantine_process`) to a static method (`_quarantine_process`) that takes a `Model<TSeq>*` parameter, and refactored its implementation to consistently use the passed model pointer for all member accesses. [[1]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L107-R107) [[2]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L794-R796)

**Codebase Consistency and Clarity:**

- Removed the now-unnecessary `m_update_model` function and its implementation, streamlining the update process in the model.

- Refactored the quarantine process logic to use the model pointer (`m`) for all member variable and method accesses, improving clarity and reducing ambiguity between static and instance context. [[1]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L794-R796) [[2]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L823-R808) [[3]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L834-R838) [[4]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L863-R864) [[5]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L887-R879) [[6]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L909-R900) [[7]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L928-R927) [[8]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L965-R957) [[9]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L988-R972) [[10]](diffhunk://#diff-bbb4b93feaa6d0e6e6e372b5d8badee989816b79174a0e8daa34d57f54d3c643L1016-R1000)