### PR TITLE
Adding rash as transmission in measlesmixing

### DIFF
--- a/docs/impl/sampling-contacts.md
+++ b/docs/impl/sampling-contacts.md
@@ -58,7 +58,7 @@ Let $r = 1 - \text{rash\_reduction\_contact\_rate}$, $r \in [0, 1]$. When $r = 0
 
 ### Expanded available pool
 
-Rash agents are *available for mixing* — they remain in the community and can be contacted by others. They therefore count toward $n_{\text{avail}}(j)$, together with Susceptible, Latent, Prodromal, and any other states that are not isolated or removed. As a result, the `adjusted_contact_rate` used for group $j$ is:
+Rash agents are *available for mixing* — they remain in the community and can be contacted by others, if the parameter "Rash reduction contact rate" is less than 1.0. They therefore count toward $n_{\text{avail}}(j)$, together with Susceptible, Latent, Prodromal, and any other states that are not isolated or removed. As a result, the `adjusted_contact_rate` used for group $j$ is:
 
 $$
 \text{adjusted\_contact\_rate}(j) = \frac{1}{n_{\text{avail}}(j)},

--- a/docs/impl/sampling-contacts.md
+++ b/docs/impl/sampling-contacts.md
@@ -47,6 +47,60 @@ This is the key difference from the old parameterization based on a global conta
 
 Since the algorithm only draws infectious contacts, it avoids spending time drawing non-infectious contacts that cannot affect transmission. Once the number of infectious contacts from each group has been sampled, infectious agents are selected uniformly at random from that group's current infectious list.
 
+## Two-pool contact sampling: Rash agents in the MeaslesMixing model
+
+In the `ModelMeaslesMixing` model the infectious population is split into two pools:
+
+- **Primary infectious** (Prodromal): fully infectious agents, sampled at the full contact rate.
+- **Reduced infectious** (Rash): agents with visible symptoms whose contact behaviour is reduced by a factor controlled by the `rash_reduction_contact_rate` parameter.
+
+Let $r = 1 - \text{rash\_reduction\_contact\_rate}$, $r \in [0, 1]$. When $r = 0$ Rash agents make no contacts; when $r = 1$ they behave identically to Prodromal agents.
+
+### Expanded available pool
+
+Rash agents are *available for mixing* — they remain in the community and can be contacted by others. They therefore count toward $n_{\text{avail}}(j)$, together with Susceptible, Latent, Prodromal, and any other states that are not isolated or removed. As a result, the `adjusted_contact_rate` used for group $j$ is:
+
+$$
+\text{adjusted\_contact\_rate}(j) = \frac{1}{n_{\text{avail}}(j)},
+$$
+
+where $n_{\text{avail}}(j)$ now includes Rash agents.
+
+### Separate binomial draws
+
+Let $n_{\text{prod}}(j)$ and $n_{\text{rash}}(j)$ denote the number of Prodromal and Rash agents in group $j$, respectively. For a susceptible focal agent in group $g$, the model draws contacts from each group $j$ in two independent steps:
+
+$$
+X_{\text{prod}}(g,j) \sim \text{Binomial}\!\left(n_{\text{prod}}(j),\; \frac{C(g,j)}{n_{\text{avail}}(j)}\right),
+$$
+
+$$
+X_{\text{rash}}(g,j) \sim \text{Binomial}\!\left(n_{\text{rash}}(j),\; r \cdot \frac{C(g,j)}{n_{\text{avail}}(j)}\right).
+$$
+
+In code this corresponds to:
+
+```cpp
+// Primary pool (Prodromal)
+rbinom(n_primary_infectious_per_group[g], base_rate)
+
+// Reduced pool (Rash)
+rbinom(n_reduced_infectious_per_group[g], r * base_rate)
+```
+
+where `base_rate = adjusted_contact_rate[j] * contact_matrix[j * n_groups + g]` and `r = 1 - model.par("Rash reduction contact rate")`.
+
+### Expected contacts
+
+The expected total number of infectious contacts from group $j$ for an agent in group $g$ is:
+
+$$
+\mathbb{E}\!\left[X_{\text{prod}}(g,j) + X_{\text{rash}}(g,j)\right]
+= C(g,j) \cdot \frac{n_{\text{prod}}(j) + r \cdot n_{\text{rash}}(j)}{n_{\text{avail}}(j)}.
+$$
+
+When all agents are in the Prodromal state ($n_{\text{rash}} = 0$) and none are quarantined or isolated ($n_{\text{avail}} = n_{\text{prod}}$), the expression reduces to $C(g, j)$, recovering the standard single-pool result.
+
 ## Mixing models with quarantine
 
 When the model features quarantine, isolation, hospitalization, or any other mechanism that removes agents from the mixing pool, the quantity $n_{\text{avail}}(j)$ changes over time. The contact matrix $C$ does not change, but the binomial sampling probability does:

--- a/include/measles/measlesmixing.hpp
+++ b/include/measles/measlesmixing.hpp
@@ -1,6 +1,8 @@
 #ifndef EPIWORLD_MODELS_MEASLESMIXING_HPP
 #define EPIWORLD_MODELS_MEASLESMIXING_HPP
 
+#include "samplermixing.hpp"
+
 using namespace epiworld;
 
 #define MM(i, j, n) \
@@ -20,7 +22,7 @@ using namespace epiworld;
  * - Population mixing based on contact matrices
  * - Measles-specific disease progression: Susceptible → Latent → Prodromal → Rash
  * - Prodromal individuals are infectious (replace the "Infected" state in SEIR)
- * - Rash individuals are no longer infectious but can be detected for isolation
+ * - Rash individuals can have reduced infectious contact and can be detected for isolation
  * - Quarantine measures for latent contacts during contact tracing
  * - Isolation policies for detected individuals during the rash state
  * - Contact tracing with configurable success rates
@@ -32,7 +34,7 @@ using namespace epiworld;
  * - Susceptible: Individuals who can become infected
  * - Latent: Infected but not yet infectious (incubation period)
  * - Prodromal: Infectious individuals in the community (replaces "Infected" in SEIR)
- * - Rash: Non-infectious individuals with visible symptoms (detection occurs here)
+ * - Rash: Individuals with visible symptoms; detection and reduced-contact sampling occur here
  * - Isolated: Detected individuals in self-isolation
  * - Isolated Recovered: Recovered individuals still in isolation
  * - Detected Hospitalized: Hospitalized individuals who were contact-traced
@@ -60,34 +62,8 @@ class ModelMeaslesMixing final :
 {
 private:
 
-    // Vector of vectors of infected agents (prodromal agents are infectious)
-    std::vector< size_t > infectious;
-    std::vector< size_t > infectious_rash;
-
-    // Number of infectious agents in each group
-    std::vector< size_t > n_infectious_per_group;
-    std::vector< size_t > n_infectious_per_group_rash;
-    
-    // Indicates how important are prodromal agents
-    // compared to rash agents when sampling contacts
-    // 1 - this vector returns the importance for
-    // rash agents.
-    std::vector< double > ingroup_weights_prodromal;
-
-    // Where the agents start in the `infectious` vector
-    std::vector< size_t > entity_indices;
-
+    SamplerMixing<TSeq> sampler;
     void _update_infectious_list();
-    std::vector< size_t > sampled_agents;
-    size_t sample_agents(
-        Agent<TSeq> * agent,
-        std::vector< size_t > & sampled_agents
-        );
-    std::vector< double > adjusted_contact_rate;
-
-    #ifdef EPI_DEBUG
-    std::vector< int > sampled_sizes;
-    #endif
 
     // Update functions
     static void _update_susceptible(Agent<TSeq> * p, Model<TSeq> * m);
@@ -255,200 +231,7 @@ public:
 template<typename TSeq>
 inline void ModelMeaslesMixing<TSeq>::_update_infectious_list()
 {
-
-    auto & agents = this->get_agents();
-
-    // Resetting infectious list
-    std::fill(n_infectious_per_group.begin(), n_infectious_per_group.end(), 0u);
-    std::fill(
-        n_infectious_per_group_rash.begin(),
-        n_infectious_per_group_rash.end(),
-        0u
-    );
-
-    // Resetting the number of available contacts
-    adjusted_contact_rate.assign(this->entities.size(), 0.0);
-
-    // This will trigger adding the rash agents or not
-    double rash_c_rate = 1.0 - this->par("Rash reduction contact rate");
-
-    bool include_rash = rash_c_rate > 0.0;
-
-    for (const auto & a : agents)
-    {
-
-        // Both Prodromal and Rash are infectious
-        auto state = a.get_state();
-        auto n_entities = a.get_n_entities();
-        if (state == PRODROMAL)
-        {
-            if (n_entities > 0u)
-            {
-                const auto & entity = a.get_entity(0u, *this);
-                infectious[
-                    // Position of the group in the `infectious` vector
-                    entity_indices[entity.get_id()] +
-                    // Position of the agent in the group
-                    n_infectious_per_group[entity.get_id()]++
-                ] = a.get_id();
-
-            }
-        } else if (include_rash && (state == RASH))
-        {
-
-            if (n_entities > 0u)
-            {
-                const auto & entity = a.get_entity(0u, *this);
-                infectious_rash[
-                    // Position of the group in the `infectious` vector
-                    entity_indices[entity.get_id()] +
-                    // Position of the agent in the group
-                    n_infectious_per_group_rash[entity.get_id()]++
-                ] = a.get_id();
-
-            }
-        }
-
-        // Setting how many agents are available for contact
-        // Rash agents also count, but have a reduced contact
-        // rate later
-        if (
-            (
-                (state < RASH) ||
-                (include_rash && (state == RASH)) ||
-                (state == RECOVERED)
-            ) &&
-            (n_entities > 0u)
-        )
-        {
-            adjusted_contact_rate[
-                a.get_entity(0u, *this).get_id()
-            ] += 1.0;
-        }
-
-    }
-
-    // This simplifies calculations later
-    for (auto & rate: adjusted_contact_rate)
-    {
-        if (rate > 0.0)
-            rate = 1.0 / rate;
-        else
-            rate = 0.0;  // No available contacts in this group
-
-        if (rate > 1.0)
-            rate = 1.0;
-    }
-
-    // Resetting the relative weight of prodromal agents when
-    // sampling contacts
-    if (include_rash)
-    {
-        ingroup_weights_prodromal.assign(this->entities.size(), 0.0);
-
-        for (size_t g = 0; g < this->entities.size(); ++g)
-        {
-            auto tot =
-                n_infectious_per_group[g] +
-                n_infectious_per_group_rash[g] * rash_c_rate;
-            if (tot > 0)
-            ingroup_weights_prodromal[g] =
-                static_cast<double>(n_infectious_per_group[g]) / tot; 
-        }
-    }
-    else
-    {
-        ingroup_weights_prodromal.assign(this->entities.size(), 1.0);
-    }
-
-    return;
-
-}
-
-template<typename TSeq>
-inline size_t ModelMeaslesMixing<TSeq>::sample_agents(
-    Agent<TSeq> * agent,
-    std::vector< size_t > & sampled_agents
-    )
-{
-
-    size_t agent_group_id = agent->get_entity(0u, *this).get_id();
-    size_t ngroups = this->entities.size();
-
-    int samp_id = 0;
-    for (size_t g = 0; g < ngroups; ++g)
-    {
-
-        size_t group_size = n_infectious_per_group[g] + n_infectious_per_group_rash[g];
-
-        if (group_size == 0u)
-            continue;
-
-        // How many from this entity?
-        int nsamples = this->rbinom(
-            group_size,
-            adjusted_contact_rate[g] *
-                this->get_contact_rate(agent_group_id, g, false)
-        );
-
-        if (nsamples == 0)
-            continue;
-
-        // Sampling from the entity
-        for (int s = 0; s < nsamples; ++s)
-        {
-
-            // Right now is two draws, but it's OK for the moment
-            bool sample_prodromal = true;
-            uint32_t which = 0u;
-            if (n_infectious_per_group_rash[g] == 0) // Original behavior (no need to dist)
-            {
-                which = this->runif_index(n_infectious_per_group[g]);
-            }
-            else 
-            {
-                sample_prodromal = this->runif() < ingroup_weights_prodromal[g];
-                if (sample_prodromal && n_infectious_per_group[g] > 0)
-                {
-                    which = this->runif_index(n_infectious_per_group[g]);
-                }
-                else
-                {
-                    which = this->runif_index(n_infectious_per_group_rash[g]);
-                }
-            }
-
-            #ifdef EPI_DEBUG
-            auto & a = this->population.at(
-                sample_prodromal ? infectious.at(entity_indices[g] + which) :
-                    infectious_rash.at(entity_indices[g] + which)
-            );
-            #else
-            auto & a = this->get_agent(
-                sample_prodromal ? infectious[entity_indices[g] + which] :
-                    infectious_rash.at(entity_indices[g] + which)
-            );
-            #endif
-
-            #ifdef EPI_DEBUG
-            if (a.get_state() != PRODROMAL)
-                throw std::logic_error(
-                    "The agent is not in prodromal state, but it should be."
-                );
-            #endif
-
-            // Can't sample itself
-            if (a.get_id() == agent->get_id())
-                continue;
-
-            sampled_agents[samp_id++] = a.get_id();
-
-        }
-
-    }
-
-    return samp_id;
-
+    sampler.update(*this);
 }
 
 template<typename TSeq>
@@ -485,32 +268,7 @@ inline void ModelMeaslesMixing<TSeq>::reset()
     size_t nentities = this->entities.size();
     validate_contact_matrix(nentities);
 
-    // Do it the first time only
-    sampled_agents.resize(this->size());
-
-    // We only do it once
-    n_infectious_per_group.assign(this->entities.size(), 0u);
-    n_infectious_per_group_rash.assign(this->entities.size(), 0u);
-    ingroup_weights_prodromal.assign(this->entities.size(), 1.0);
-
-    // We are assuming one agent per entity
-    infectious.assign(this->size(), 0u);
-    infectious_rash.assign(this->size(), 0u);
-
-    // This will say when do the groups start in the `infectious` vector
-    entity_indices.assign(this->entities.size(), 0u);
-
-    for (size_t i = 1u; i < this->entities.size(); ++i)
-    {
-
-        entity_indices[i] +=
-            this->entities[i - 1].size() +
-            entity_indices[i - 1]
-            ;
-        }
-
-
-    this->_update_infectious_list();
+    sampler.reset(*this);
 
     // Setting up the quarantine parameters
     quarantine_willingness.assign(this->size(), false);
@@ -552,10 +310,11 @@ inline void ModelMeaslesMixing<TSeq>::_update_susceptible(
     // class
     auto * m_down = model_cast<ModelMeaslesMixing<TSeq>, TSeq>(m);
 
-    size_t ndraws = m_down->sample_agents(p, m_down->sampled_agents);
+    size_t ndraws = m_down->sampler.sample(p, *m_down, *m_down);
+    const auto & sampled_agents = m_down->sampler.get_sampled_agents();
 
     #ifdef EPI_DEBUG
-    m_down->sampled_sizes.push_back(static_cast<int>(ndraws));
+    m_down->sampler.record_sampled_size(ndraws);
     #endif
 
     if (ndraws == 0u)
@@ -567,7 +326,7 @@ inline void ModelMeaslesMixing<TSeq>::_update_susceptible(
     for (size_t n = 0u; n < ndraws; ++n)
     {
 
-        auto & neighbor = m->get_agent(m_down->sampled_agents[n]);
+        auto & neighbor = m->get_agent(sampled_agents[n]);
 
         auto & v = neighbor.get_virus();
 
@@ -1029,6 +788,14 @@ inline ModelMeaslesMixing<TSeq>::ModelMeaslesMixing(
     this->add_param(vax_efficacy, "Vax efficacy");
     this->add_param(vax_reduction_recovery_rate, "(IGNORED) Vax improved recovery");
     this->add_param(rash_reduction_contact_rate, "Rash reduction contact rate");
+
+    sampler.configure(
+        PRODROMAL,
+        RASH,
+        RECOVERED,
+        "Rash reduction contact rate",
+        {SUSCEPTIBLE, LATENT, PRODROMAL, RECOVERED}
+    );
 
     // state
     this->add_state("Susceptible", _update_susceptible);

--- a/include/measles/measlesmixing.hpp
+++ b/include/measles/measlesmixing.hpp
@@ -792,7 +792,6 @@ inline ModelMeaslesMixing<TSeq>::ModelMeaslesMixing(
     sampler.configure(
         PRODROMAL,
         RASH,
-        RECOVERED,
         "Rash reduction contact rate",
         {SUSCEPTIBLE, LATENT, PRODROMAL, RECOVERED}
     );

--- a/include/measles/measlesmixing.hpp
+++ b/include/measles/measlesmixing.hpp
@@ -62,9 +62,17 @@ private:
 
     // Vector of vectors of infected agents (prodromal agents are infectious)
     std::vector< size_t > infectious;
+    std::vector< size_t > infectious_rash;
 
     // Number of infectious agents in each group
     std::vector< size_t > n_infectious_per_group;
+    std::vector< size_t > n_infectious_per_group_rash;
+    
+    // Indicates how important are prodromal agents
+    // compared to rash agents when sampling contacts
+    // 1 - this vector returns the importance for
+    // rash agents.
+    std::vector< double > ingroup_weights_prodromal;
 
     // Where the agents start in the `infectious` vector
     std::vector< size_t > entity_indices;
@@ -184,7 +192,8 @@ public:
         epiworld_fast_int isolation_period,
         epiworld_double prop_vaccinated,
         epiworld_double contact_tracing_success_rate = 1.0,
-        epiworld_fast_uint contact_tracing_days_window = 4u
+        epiworld_fast_uint contact_tracing_days_window = 4u,
+        epiworld_double rash_reduction_contact_rate = 1.0
     );
 
     /**
@@ -251,16 +260,29 @@ inline void ModelMeaslesMixing<TSeq>::_update_infectious_list()
 
     // Resetting infectious list
     std::fill(n_infectious_per_group.begin(), n_infectious_per_group.end(), 0u);
+    std::fill(
+        n_infectious_per_group_rash.begin(),
+        n_infectious_per_group_rash.end(),
+        0u
+    );
 
     // Resetting the number of available contacts
     adjusted_contact_rate.assign(this->entities.size(), 0.0);
 
+    // This will trigger adding the rash agents or not
+    double rash_c_rate = 1.0 - this->par("Rash reduction contact rate");
+
+    bool include_rash = rash_c_rate > 0.0;
+
     for (const auto & a : agents)
     {
 
-        if (a.get_state() == PRODROMAL)
+        // Both Prodromal and Rash are infectious
+        auto state = a.get_state();
+        auto n_entities = a.get_n_entities();
+        if (state == PRODROMAL)
         {
-            if (a.get_n_entities() > 0u)
+            if (n_entities > 0u)
             {
                 const auto & entity = a.get_entity(0u, *this);
                 infectious[
@@ -271,12 +293,32 @@ inline void ModelMeaslesMixing<TSeq>::_update_infectious_list()
                 ] = a.get_id();
 
             }
+        } else if (include_rash && (state == RASH))
+        {
+
+            if (n_entities > 0u)
+            {
+                const auto & entity = a.get_entity(0u, *this);
+                infectious_rash[
+                    // Position of the group in the `infectious` vector
+                    entity_indices[entity.get_id()] +
+                    // Position of the agent in the group
+                    n_infectious_per_group_rash[entity.get_id()]++
+                ] = a.get_id();
+
+            }
         }
 
         // Setting how many agents are available for contact
+        // Rash agents also count, but have a reduced contact
+        // rate later
         if (
-            ((a.get_state() < RASH) || (a.get_state() == RECOVERED)) &&
-            (a.get_n_entities() > 0u)
+            (
+                (state < RASH) ||
+                (include_rash && (state == RASH)) ||
+                (state == RECOVERED)
+            ) &&
+            (n_entities > 0u)
         )
         {
             adjusted_contact_rate[
@@ -298,6 +340,27 @@ inline void ModelMeaslesMixing<TSeq>::_update_infectious_list()
             rate = 1.0;
     }
 
+    // Resetting the relative weight of prodromal agents when
+    // sampling contacts
+    if (include_rash)
+    {
+        ingroup_weights_prodromal.assign(this->entities.size(), 0.0);
+
+        for (size_t g = 0; g < this->entities.size(); ++g)
+        {
+            auto tot =
+                n_infectious_per_group[g] +
+                n_infectious_per_group_rash[g] * rash_c_rate;
+            if (tot > 0)
+            ingroup_weights_prodromal[g] =
+                static_cast<double>(n_infectious_per_group[g]) / tot; 
+        }
+    }
+    else
+    {
+        ingroup_weights_prodromal.assign(this->entities.size(), 1.0);
+    }
+
     return;
 
 }
@@ -316,7 +379,7 @@ inline size_t ModelMeaslesMixing<TSeq>::sample_agents(
     for (size_t g = 0; g < ngroups; ++g)
     {
 
-        size_t group_size = n_infectious_per_group[g];
+        size_t group_size = n_infectious_per_group[g] + n_infectious_per_group_rash[g];
 
         if (group_size == 0u)
             continue;
@@ -324,7 +387,8 @@ inline size_t ModelMeaslesMixing<TSeq>::sample_agents(
         // How many from this entity?
         int nsamples = this->rbinom(
             group_size,
-            adjusted_contact_rate[g] * this->get_contact_rate(agent_group_id, g, false)
+            adjusted_contact_rate[g] *
+                this->get_contact_rate(agent_group_id, g, false)
         );
 
         if (nsamples == 0)
@@ -334,13 +398,36 @@ inline size_t ModelMeaslesMixing<TSeq>::sample_agents(
         for (int s = 0; s < nsamples; ++s)
         {
 
-            // Randomly selecting an agent
-            auto which = this->runif_index(group_size); 
+            // Right now is two draws, but it's OK for the moment
+            bool sample_prodromal = true;
+            uint32_t which = 0u;
+            if (n_infectious_per_group_rash[g] == 0) // Original behavior (no need to dist)
+            {
+                which = this->runif_index(n_infectious_per_group[g]);
+            }
+            else 
+            {
+                sample_prodromal = this->runif() < ingroup_weights_prodromal[g];
+                if (sample_prodromal && n_infectious_per_group[g] > 0)
+                {
+                    which = this->runif_index(n_infectious_per_group[g]);
+                }
+                else
+                {
+                    which = this->runif_index(n_infectious_per_group_rash[g]);
+                }
+            }
 
             #ifdef EPI_DEBUG
-            auto & a = this->population.at(infectious.at(entity_indices[g] + which));
+            auto & a = this->population.at(
+                sample_prodromal ? infectious.at(entity_indices[g] + which) :
+                    infectious_rash.at(entity_indices[g] + which)
+            );
             #else
-            auto & a = this->get_agent(infectious[entity_indices[g] + which]);
+            auto & a = this->get_agent(
+                sample_prodromal ? infectious[entity_indices[g] + which] :
+                    infectious_rash.at(entity_indices[g] + which)
+            );
             #endif
 
             #ifdef EPI_DEBUG
@@ -403,9 +490,12 @@ inline void ModelMeaslesMixing<TSeq>::reset()
 
     // We only do it once
     n_infectious_per_group.assign(this->entities.size(), 0u);
+    n_infectious_per_group_rash.assign(this->entities.size(), 0u);
+    ingroup_weights_prodromal.assign(this->entities.size(), 1.0);
 
     // We are assuming one agent per entity
     infectious.assign(this->size(), 0u);
+    infectious_rash.assign(this->size(), 0u);
 
     // This will say when do the groups start in the `infectious` vector
     entity_indices.assign(this->entities.size(), 0u);
@@ -417,8 +507,8 @@ inline void ModelMeaslesMixing<TSeq>::reset()
             this->entities[i - 1].size() +
             entity_indices[i - 1]
             ;
+        }
 
-    }
 
     this->_update_infectious_list();
 
@@ -890,7 +980,8 @@ inline ModelMeaslesMixing<TSeq>::ModelMeaslesMixing(
     epiworld_fast_int isolation_period,
     epiworld_double prop_vaccinated,
     epiworld_double contact_tracing_success_rate,
-    epiworld_fast_uint contact_tracing_days_window
+    epiworld_fast_uint contact_tracing_days_window,
+    epiworld_double rash_reduction_contact_rate
     )
 {
 
@@ -915,7 +1006,7 @@ inline ModelMeaslesMixing<TSeq>::ModelMeaslesMixing(
     EpiAssert::check_bounds(quarantine_willingness, 0.0, 1.0, "quarantine_willingness", "ModelMeaslesMixing");
     EpiAssert::check_bounds(isolation_period, -1, max_int, "isolation_period", "ModelMeaslesMixing");
     EpiAssert::check_probability(contact_tracing_success_rate, "contact_tracing_success_rate", "ModelMeaslesMixing");
-
+    EpiAssert::check_bounds(rash_reduction_contact_rate, 0.0, 1.0, "rash_reduction_contact_rate", "ModelMeaslesMixing");
 
     // Setting up the contact matrix
     this->set_contact_matrix(contact_matrix, true);
@@ -937,6 +1028,7 @@ inline ModelMeaslesMixing<TSeq>::ModelMeaslesMixing(
     this->add_param(prop_vaccinated, "Vaccination rate");
     this->add_param(vax_efficacy, "Vax efficacy");
     this->add_param(vax_reduction_recovery_rate, "(IGNORED) Vax improved recovery");
+    this->add_param(rash_reduction_contact_rate, "Rash reduction contact rate");
 
     // state
     this->add_state("Susceptible", _update_susceptible);

--- a/include/measles/samplermixing.hpp
+++ b/include/measles/samplermixing.hpp
@@ -22,7 +22,6 @@ private:
 
     int primary_infectious_state = -1;
     int reduced_infectious_state = -1;
-    int recovered_state = -1;
     std::string reduced_contact_reduction_param;
     std::vector< int > contact_states;
 
@@ -32,7 +31,6 @@ private:
     std::vector< size_t > n_primary_infectious_per_group;
     std::vector< size_t > n_reduced_infectious_per_group;
 
-    std::vector< double > ingroup_weights_primary;
     std::vector< size_t > entity_indices;
     std::vector< double > adjusted_contact_rate;
     std::vector< size_t > sampled_agents;
@@ -56,7 +54,6 @@ public:
      *
      * @param primary_infectious_state_ State index for fully infectious agents.
      * @param reduced_infectious_state_ State index for reduced-infectious agents.
-     * @param recovered_state_ State index considered recovered/immune.
      * @param reduced_contact_reduction_param_ Model parameter name controlling
      * reduced infectious contact reduction.
      * @param contact_states_ Explicit states eligible for contact.
@@ -64,7 +61,6 @@ public:
     SamplerMixing(
         int primary_infectious_state_,
         int reduced_infectious_state_,
-        int recovered_state_,
         std::string reduced_contact_reduction_param_,
         std::vector< int > contact_states_
     );
@@ -74,7 +70,6 @@ public:
      *
      * @param primary_infectious_state_ State index for fully infectious agents.
      * @param reduced_infectious_state_ State index for reduced-infectious agents.
-     * @param recovered_state_ State index considered recovered/immune.
      * @param reduced_contact_reduction_param_ Model parameter name controlling
      * reduced infectious contact reduction.
      * @param contact_states_ Explicit states eligible for contact.
@@ -82,7 +77,6 @@ public:
     void configure(
         int primary_infectious_state_,
         int reduced_infectious_state_,
-        int recovered_state_,
         std::string reduced_contact_reduction_param_,
         std::vector< int > contact_states_
     );
@@ -175,7 +169,6 @@ template<typename TSeq>
 inline SamplerMixing<TSeq>::SamplerMixing(
     int primary_infectious_state_,
     int reduced_infectious_state_,
-    int recovered_state_,
     std::string reduced_contact_reduction_param_,
     std::vector< int > contact_states_
 )
@@ -183,7 +176,6 @@ inline SamplerMixing<TSeq>::SamplerMixing(
     configure(
         primary_infectious_state_,
         reduced_infectious_state_,
-        recovered_state_,
         reduced_contact_reduction_param_,
         contact_states_
     );
@@ -193,14 +185,12 @@ template<typename TSeq>
 inline void SamplerMixing<TSeq>::configure(
     int primary_infectious_state_,
     int reduced_infectious_state_,
-    int recovered_state_,
     std::string reduced_contact_reduction_param_,
     std::vector< int > contact_states_
 )
 {
     primary_infectious_state = primary_infectious_state_;
     reduced_infectious_state = reduced_infectious_state_;
-    recovered_state = recovered_state_;
     reduced_contact_reduction_param = reduced_contact_reduction_param_;
     contact_states = contact_states_;
 }
@@ -242,7 +232,6 @@ inline void SamplerMixing<TSeq>::reset(Model<TSeq> & model)
     sampled_agents.resize(model.size());
     n_primary_infectious_per_group.assign(entities.size(), 0u);
     n_reduced_infectious_per_group.assign(entities.size(), 0u);
-    ingroup_weights_primary.assign(entities.size(), 1.0);
 
     primary_infectious.assign(model.size(), 0u);
     reduced_infectious.assign(model.size(), 0u);
@@ -332,29 +321,6 @@ inline void SamplerMixing<TSeq>::update(Model<TSeq> & model)
 
         if (rate > 1.0)
             rate = 1.0;
-    }
-
-    if (include_reduced)
-    {
-        ingroup_weights_primary.assign(entities.size(), 0.0);
-
-        for (size_t g = 0; g < entities.size(); ++g)
-        {
-            auto tot =
-                n_primary_infectious_per_group[g] +
-                n_reduced_infectious_per_group[g] * reduced_contact_rate;
-
-            if (tot > 0.0)
-            {
-                ingroup_weights_primary[g] =
-                    static_cast<double>(n_primary_infectious_per_group[g]) /
-                    tot;
-            }
-        }
-    }
-    else
-    {
-        ingroup_weights_primary.assign(entities.size(), 1.0);
     }
 }
 

--- a/include/measles/samplermixing.hpp
+++ b/include/measles/samplermixing.hpp
@@ -1,0 +1,476 @@
+#ifndef EPIWORLD_MODELS_SAMPLERMIXING_HPP
+#define EPIWORLD_MODELS_SAMPLERMIXING_HPP
+
+using namespace epiworld;
+
+/**
+ * @brief Reusable contact sampler for mixing models with two infectious stages.
+ *
+ * The sampler keeps the per-entity infectious-agent accounting and contact
+ * sampling buffer used by ModelMeaslesMixing. The primary infectious state is
+ * sampled at full weight; the reduced infectious state is sampled with a
+ * relative contact rate computed as 1 minus a model parameter such as
+ * "Rash reduction contact rate".
+ *
+ * @tparam TSeq Type for genetic sequences (default: EPI_DEFAULT_TSEQ)
+ * @ingroup disease_specific
+ */
+template<typename TSeq = EPI_DEFAULT_TSEQ>
+class SamplerMixing
+{
+private:
+
+    int primary_infectious_state = -1;
+    int reduced_infectious_state = -1;
+    int recovered_state = -1;
+    std::string reduced_contact_reduction_param;
+    std::vector< int > contact_states;
+
+    std::vector< size_t > primary_infectious;
+    std::vector< size_t > reduced_infectious;
+
+    std::vector< size_t > n_primary_infectious_per_group;
+    std::vector< size_t > n_reduced_infectious_per_group;
+
+    std::vector< double > ingroup_weights_primary;
+    std::vector< size_t > entity_indices;
+    std::vector< double > adjusted_contact_rate;
+    std::vector< size_t > sampled_agents;
+
+    double get_reduced_contact_rate(Model<TSeq> & model) const;
+    bool is_available_for_contact(int state, bool include_reduced) const;
+
+    #ifdef EPI_DEBUG
+    std::vector< int > sampled_sizes;
+    #endif
+
+public:
+
+    /**
+     * @brief Default constructor.
+     */
+    SamplerMixing() = default;
+
+    /**
+     * @brief Constructs and configures the sampler.
+     *
+     * @param primary_infectious_state_ State index for fully infectious agents.
+     * @param reduced_infectious_state_ State index for reduced-infectious agents.
+     * @param recovered_state_ State index considered recovered/immune.
+     * @param reduced_contact_reduction_param_ Model parameter name controlling
+     * reduced infectious contact reduction.
+     * @param contact_states_ Explicit states eligible for contact.
+     */
+    SamplerMixing(
+        int primary_infectious_state_,
+        int reduced_infectious_state_,
+        int recovered_state_,
+        std::string reduced_contact_reduction_param_,
+        std::vector< int > contact_states_
+    );
+
+    /**
+     * @brief Configures state indices and contact-selection settings.
+     *
+     * @param primary_infectious_state_ State index for fully infectious agents.
+     * @param reduced_infectious_state_ State index for reduced-infectious agents.
+     * @param recovered_state_ State index considered recovered/immune.
+     * @param reduced_contact_reduction_param_ Model parameter name controlling
+     * reduced infectious contact reduction.
+     * @param contact_states_ Explicit states eligible for contact.
+     */
+    void configure(
+        int primary_infectious_state_,
+        int reduced_infectious_state_,
+        int recovered_state_,
+        std::string reduced_contact_reduction_param_,
+        std::vector< int > contact_states_
+    );
+
+    /**
+     * @brief Resets internal buffers and recomputes infectious pools.
+     *
+     * @param model Model containing current agents and entities.
+     */
+    void reset(Model<TSeq> & model);
+
+    /**
+     * @brief Updates infectious pools and per-group sampling weights.
+     *
+     * @param model Model containing current agents and entities.
+     */
+    void update(Model<TSeq> & model);
+
+    /**
+     * @brief Samples infectious contacts into the internal sampled-agent buffer.
+     *
+     * @param agent Agent for which contacts are sampled.
+     * @param model Model containing current agent states.
+     * @param contact_matrix Matrix with between-group contact rates.
+     *
+     * @return Number of sampled contacts written to the internal buffer.
+     */
+    size_t sample(
+        Agent<TSeq> * agent,
+        Model<TSeq> & model,
+        const ContactMatrix & contact_matrix
+    );
+
+    /**
+     * @brief Samples infectious contacts into a user-provided buffer.
+     *
+     * @param agent Agent for which contacts are sampled.
+     * @param model Model containing current agent states.
+     * @param contact_matrix Matrix with between-group contact rates.
+     * @param sampled_agents_ Output buffer receiving sampled agent ids.
+     *
+     * @return Number of sampled contacts written to @p sampled_agents_.
+     */
+    size_t sample(
+        Agent<TSeq> * agent,
+        Model<TSeq> & model,
+        const ContactMatrix & contact_matrix,
+        std::vector< size_t > & sampled_agents_
+    );
+
+    /**
+     * @brief Returns the internal sampled-agent buffer (const).
+     */
+    const std::vector< size_t > & get_sampled_agents() const
+    {
+        return sampled_agents;
+    }
+
+    /**
+     * @brief Returns the internal sampled-agent buffer.
+     */
+    std::vector< size_t > & get_sampled_agents()
+    {
+        return sampled_agents;
+    }
+
+    #ifdef EPI_DEBUG
+    /**
+     * @brief Records the number of sampled contacts in debug mode.
+     *
+     * @param n Number of contacts sampled in a call.
+     */
+    void record_sampled_size(size_t n)
+    {
+        sampled_sizes.push_back(static_cast<int>(n));
+    }
+
+    /**
+     * @brief Returns the debug history of sampled-contact counts.
+     */
+    const std::vector< int > & get_sampled_sizes() const
+    {
+        return sampled_sizes;
+    }
+    #endif
+
+};
+
+template<typename TSeq>
+inline SamplerMixing<TSeq>::SamplerMixing(
+    int primary_infectious_state_,
+    int reduced_infectious_state_,
+    int recovered_state_,
+    std::string reduced_contact_reduction_param_,
+    std::vector< int > contact_states_
+)
+{
+    configure(
+        primary_infectious_state_,
+        reduced_infectious_state_,
+        recovered_state_,
+        reduced_contact_reduction_param_,
+        contact_states_
+    );
+}
+
+template<typename TSeq>
+inline void SamplerMixing<TSeq>::configure(
+    int primary_infectious_state_,
+    int reduced_infectious_state_,
+    int recovered_state_,
+    std::string reduced_contact_reduction_param_,
+    std::vector< int > contact_states_
+)
+{
+    primary_infectious_state = primary_infectious_state_;
+    reduced_infectious_state = reduced_infectious_state_;
+    recovered_state = recovered_state_;
+    reduced_contact_reduction_param = reduced_contact_reduction_param_;
+    contact_states = contact_states_;
+}
+
+template<typename TSeq>
+inline double SamplerMixing<TSeq>::get_reduced_contact_rate(
+    Model<TSeq> & model
+) const
+{
+    if (reduced_contact_reduction_param.empty())
+        return 0.0;
+
+    return 1.0 - model.par(reduced_contact_reduction_param);
+}
+
+template<typename TSeq>
+inline bool SamplerMixing<TSeq>::is_available_for_contact(
+    int state,
+    bool include_reduced
+) const
+{
+    if (include_reduced && (state == reduced_infectious_state))
+    {
+        return true;
+    }
+
+    for (auto contact_state: contact_states)
+        if (state == contact_state)
+            return true;
+
+    return false;
+}
+
+template<typename TSeq>
+inline void SamplerMixing<TSeq>::reset(Model<TSeq> & model)
+{
+    auto & entities = model.get_entities();
+
+    sampled_agents.resize(model.size());
+    n_primary_infectious_per_group.assign(entities.size(), 0u);
+    n_reduced_infectious_per_group.assign(entities.size(), 0u);
+    ingroup_weights_primary.assign(entities.size(), 1.0);
+
+    primary_infectious.assign(model.size(), 0u);
+    reduced_infectious.assign(model.size(), 0u);
+
+    entity_indices.assign(entities.size(), 0u);
+
+    for (size_t i = 1u; i < entities.size(); ++i)
+    {
+        entity_indices[i] +=
+            entities[i - 1].size() +
+            entity_indices[i - 1]
+            ;
+    }
+
+    update(model);
+}
+
+template<typename TSeq>
+inline void SamplerMixing<TSeq>::update(Model<TSeq> & model)
+{
+    auto & agents = model.get_agents();
+    auto & entities = model.get_entities();
+
+    std::fill(
+        n_primary_infectious_per_group.begin(),
+        n_primary_infectious_per_group.end(),
+        0u
+    );
+    std::fill(
+        n_reduced_infectious_per_group.begin(),
+        n_reduced_infectious_per_group.end(),
+        0u
+    );
+
+    adjusted_contact_rate.assign(entities.size(), 0.0);
+
+    double reduced_contact_rate = get_reduced_contact_rate(model);
+    bool include_reduced = reduced_contact_rate > 0.0;
+
+    // We need to check all agents to see which ones
+    // will be included in the infectious pools
+    for (const auto & a : agents)
+    {
+        int state = static_cast<int>(a.get_state());
+        auto n_entities = a.get_n_entities();
+
+        if (state == primary_infectious_state)
+        {
+            if (n_entities > 0u)
+            {
+                const auto & entity = a.get_entity(0u, model);
+                primary_infectious[
+                    entity_indices[entity.get_id()] +
+                    n_primary_infectious_per_group[entity.get_id()]++
+                ] = a.get_id();
+            }
+        }
+        else if (include_reduced && (state == reduced_infectious_state))
+        {
+            if (n_entities > 0u)
+            {
+                const auto & entity = a.get_entity(0u, model);
+                reduced_infectious[
+                    entity_indices[entity.get_id()] +
+                    n_reduced_infectious_per_group[entity.get_id()]++
+                ] = a.get_id();
+            }
+        }
+
+        if (
+            is_available_for_contact(state, include_reduced) &&
+            (n_entities > 0u)
+        )
+        {
+            adjusted_contact_rate[
+                a.get_entity(0u, model).get_id()
+            ] += 1.0;
+        }
+    }
+
+    for (auto & rate: adjusted_contact_rate)
+    {
+        if (rate > 0.0)
+            rate = 1.0 / rate;
+        else
+            rate = 0.0;
+
+        if (rate > 1.0)
+            rate = 1.0;
+    }
+
+    if (include_reduced)
+    {
+        ingroup_weights_primary.assign(entities.size(), 0.0);
+
+        for (size_t g = 0; g < entities.size(); ++g)
+        {
+            auto tot =
+                n_primary_infectious_per_group[g] +
+                n_reduced_infectious_per_group[g] * reduced_contact_rate;
+
+            if (tot > 0.0)
+            {
+                ingroup_weights_primary[g] =
+                    static_cast<double>(n_primary_infectious_per_group[g]) /
+                    tot;
+            }
+        }
+    }
+    else
+    {
+        ingroup_weights_primary.assign(entities.size(), 1.0);
+    }
+}
+
+template<typename TSeq>
+inline size_t SamplerMixing<TSeq>::sample(
+    Agent<TSeq> * agent,
+    Model<TSeq> & model,
+    const ContactMatrix & contact_matrix
+)
+{
+    return sample(agent, model, contact_matrix, sampled_agents);
+}
+
+template<typename TSeq>
+inline size_t SamplerMixing<TSeq>::sample(
+    Agent<TSeq> * agent,
+    Model<TSeq> & model,
+    const ContactMatrix & contact_matrix,
+    std::vector< size_t > & sampled_agents_
+)
+{
+    // If the agent is not in any entity, we cannot 
+    // find them in the contact matrix.
+    if (agent->get_n_entities() == 0u)
+        return 0u;
+
+    size_t agent_group_id = agent->get_entity(0u, model).get_id();
+    size_t ngroups = model.get_entities().size();
+
+    // The reduced-contact rate for the secondary infectious pool (e.g. rash).
+    // r = 0  means no contacts at all; r = 1 means full contact rate.
+    double r = get_reduced_contact_rate(model);
+
+    // Sampling accross all groups
+    size_t samp_id = 0u;
+    for (size_t g = 0; g < ngroups; ++g)
+    {
+        double base_rate =
+            adjusted_contact_rate[g] *
+            contact_matrix.get_contact_rate(agent_group_id, g, false);
+
+        // --- Primary infectious pool (e.g. prodromal) ---
+        if (n_primary_infectious_per_group[g] > 0u)
+        {
+            int nsamples = model.rbinom(
+                static_cast<int>(n_primary_infectious_per_group[g]),
+                base_rate
+            );
+
+            for (int s = 0; s < nsamples; ++s)
+            {
+                uint32_t which = model.runif_index(
+                    n_primary_infectious_per_group[g]
+                );
+
+                #ifdef EPI_DEBUG
+                auto & a = model.get_agents().at(
+                    primary_infectious.at(entity_indices[g] + which)
+                );
+                if (static_cast<int>(a.get_state()) != primary_infectious_state)
+                    throw std::logic_error(
+                        "The sampled agent is not in the primary infectious state."
+                    );
+                #else
+                auto & a = model.get_agent(
+                    primary_infectious[entity_indices[g] + which]
+                );
+                #endif
+
+                if (a.get_id() == agent->get_id())
+                    continue;
+
+                sampled_agents_[samp_id++] = a.get_id();
+            }
+        }
+
+        // --- Reduced infectious pool (e.g. rash) ---
+        // The binomial probability is scaled by r so that the *expected*
+        // number of contacts with reduced-infectious agents is proportional
+        // to r, not just the per-contact selection weight.
+        if (n_reduced_infectious_per_group[g] > 0u && r > 0.0)
+        {
+            int nsamples = model.rbinom(
+                static_cast<int>(n_reduced_infectious_per_group[g]),
+                r * base_rate
+            );
+
+            for (int s = 0; s < nsamples; ++s)
+            {
+                uint32_t which = model.runif_index(
+                    n_reduced_infectious_per_group[g]
+                );
+
+                #ifdef EPI_DEBUG
+                auto & a = model.get_agents().at(
+                    reduced_infectious.at(entity_indices[g] + which)
+                );
+                if (static_cast<int>(a.get_state()) != reduced_infectious_state)
+                    throw std::logic_error(
+                        "The sampled agent is not in the reduced infectious state."
+                    );
+                #else
+                auto & a = model.get_agent(
+                    reduced_infectious[entity_indices[g] + which]
+                );
+                #endif
+
+                if (a.get_id() == agent->get_id())
+                    continue;
+
+                sampled_agents_[samp_id++] = a.get_id();
+            }
+        }
+    }
+
+    return samp_id;
+}
+
+#endif

--- a/tests/14c-measles.cpp
+++ b/tests/14c-measles.cpp
@@ -2,12 +2,12 @@
 #include "../include/measles/measles.hpp"
 
 #define calc_r0(ans_observed, ans_expected, r0, model) \
-    double (ans_observed) = std::accumulate(r0.begin(), r0.end(), 0.0); \
-    (ans_observed) /= static_cast<epiworld_double>(r0.size()); \
+    double ans_observed = std::accumulate(r0.begin(), r0.end(), 0.0); \
+    ans_observed /= static_cast<epiworld_double>(r0.size()); \
     std::fill(r0.begin(), r0.end(), -1.0); \
-    double (ans_expected) = (model)("Contact rate") * \
-        (model)("Transmission rate") * \
-        (model)("Prodromal period");
+    double ans_expected = model("Contact rate") * \
+        model("Transmission rate") * \
+        model("Prodromal period");
 
 using namespace epiworld;
 

--- a/tests/18a-measles-mixing.cpp
+++ b/tests/18a-measles-mixing.cpp
@@ -216,7 +216,7 @@ EPIWORLD_TEST_CASE(
 
     // Setting the contact rate reduction for rash agents to 50%
     // We also shut off isolation
-    model_0.set_param("Rash reduction contact rate", 0.5);
+    model_0.set_param("Rash reduction contact rate", 0.2);
     model_0.set_param("Isolation period", -1.0);
     
     // Change the transmission rate a bit as well
@@ -245,9 +245,9 @@ EPIWORLD_TEST_CASE(
             );
     }
     R0_observed_rash /= static_cast<epiworld_double>(nsims * n_seeds);    
-    double R0_theo_rash = contact_matrix[0] * (
-        model_0("Transmission rate") * model_0("Prodromal period") +
-        0.5 * model_0("Transmission rate") * (model_0("Rash period"))
+    double R0_theo_rash = contact_matrix[0] * model_0("Transmission rate") * (
+        model_0("Prodromal period") +
+        (1.0 - model_0("Rash reduction contact rate")) * model_0("Rash period")
     );
     double R0_naive_rash = contact_matrix[0] * model_0("Transmission rate") *
         model_0("Prodromal period");

--- a/tests/18a-measles-mixing.cpp
+++ b/tests/18a-measles-mixing.cpp
@@ -10,11 +10,11 @@ EPIWORLD_TEST_CASE(
 ) {
     
     // Queuing doesn't matter and get results that are meaningful
-    int n_seeds = 5;
+    int n_seeds = 10;
     
     // Simple contact matrix (single group, all mixing)
     std::vector<double> contact_matrix = {2.0};
-    double n_agents = 1000.0;
+    double n_agents = 2000.0;
     size_t n_agents_sz = static_cast<size_t>(n_agents);
     
     measles::ModelMeaslesMixing<> model_0(
@@ -198,6 +198,64 @@ EPIWORLD_TEST_CASE(
             0.1
         )
     );
+
+    // ========================================================================
+    // Re-running the model now including the agents with Rash (50% contact rate)
+    // This should change the R0 value
+    // ========================================================================
+    nsims = 1'000;
+    std::vector<std::vector<epiworld_double>> transitions_rash(nsims);
+    std::vector<epiworld_double> R0s_rash(nsims * n_seeds, -1.0);
+    std::vector< double > outbreak_sizes_rash(nsims, 0.0);
+    std::vector< double > hospitalizations_rash(nsims, 0.0);
+
+    auto saver_rash = tests_create_saver(
+        transitions_rash, R0s_rash, n_seeds, nullptr,
+        &outbreak_sizes_rash, &hospitalizations_rash
+    );
+
+    // Setting the contact rate reduction for rash agents to 50%
+    // We also shut off isolation
+    model_0.set_param("Rash reduction contact rate", 0.5);
+    model_0.set_param("Isolation period", -1.0);
+    
+    // Change the transmission rate a bit as well
+    // model_0.set_param("Transmission rate", model_0("Transmission rate") * 0.75);
+
+    model_0.
+        run_multiple(100, nsims, 1231, saver_rash, true, true, 4).
+        print(false);
+
+    // Calculate average transitions
+    auto avg_transitions_rash = tests_calculate_avg_transitions(
+        transitions_rash, model_0
+    );
+
+    tests_print_avg_transitions(avg_transitions_rash, model_0);
+
+    // Average R0
+    double R0_observed_rash = 0.0;
+    for (auto & i: R0s_rash)
+    {
+        if (i >= 0.0)
+            R0_observed_rash += i;
+        else
+            throw std::range_error(
+                "The R0 value is negative. This should not happen."
+            );
+    }
+    R0_observed_rash /= static_cast<epiworld_double>(nsims * n_seeds);    
+    double R0_theo_rash = contact_matrix[0] * (
+        model_0("Transmission rate") * model_0("Prodromal period") +
+        0.5 * model_0("Transmission rate") * (model_0("Rash period"))
+    );
+    double R0_naive_rash = contact_matrix[0] * model_0("Transmission rate") *
+        model_0("Prodromal period");
+
+    std::cout << "Reproductive number with rash: "
+              << R0_observed_rash << " (expected ~" << R0_theo_rash << ")" 
+              << " (Prodromal only ~" << R0_naive_rash << ")" << std::endl;
+
     
     
     #undef mat

--- a/tests/18a-measles-mixing.cpp
+++ b/tests/18a-measles-mixing.cpp
@@ -214,7 +214,7 @@ EPIWORLD_TEST_CASE(
         &outbreak_sizes_rash, &hospitalizations_rash
     );
 
-    // Setting the contact rate reduction for rash agents to 50%
+    // Setting the contact rate reduction for rash agents to 20%
     // We also shut off isolation
     model_0.set_param("Rash reduction contact rate", 0.2);
     model_0.set_param("Isolation period", -1.0);

--- a/tests/18f-measles-mixing-r0s.cpp
+++ b/tests/18f-measles-mixing-r0s.cpp
@@ -1,0 +1,141 @@
+
+#include "tests.hpp"
+#include "../include/measles/measles.hpp"
+
+using namespace epiworld;
+
+EPIWORLD_TEST_CASE(
+    "Measles model with mixing R0s",
+    "[ModelMeaslesMixingOff]"
+) {
+    
+    // Queuing doesn't matter and get results that are meaningful
+    size_t nsims = 400; // Reduced for faster testing
+    int n_seeds = 1;
+    
+    // Simple contact matrix (single group, all mixing)
+    std::vector<double> contact_matrix = {4.0};
+    double n_agents = 2000.0;
+    size_t n_agents_sz = static_cast<size_t>(n_agents);
+    
+    measles::ModelMeaslesMixing<> model_0(
+        n_agents_sz, // Number of agents
+        n_seeds / n_agents, // Initial prevalence
+        0.1,         // Transmission rate
+        0.9,         // Vaccination efficacy
+        0.3,         // Vaccination reduction recovery rate
+        7.0,         // Incubation period
+        4.0,         // Prodromal period
+        5.0,         // Rash period
+        contact_matrix, // Contact matrix
+        0.1,         // Hospitalization rate
+        7.0,         // Hospitalization duration
+        3.0,         // Days undetected
+        21,          // Quarantine period
+        .8,          // Quarantine willingness
+        .8,          // Isolation willingness
+        4,           // Isolation period
+        0.0,         // Proportion vaccinated
+        1.0,         // Contact tracing success rate
+        4u           // Contact tracing days prior
+    );
+
+    // Shutting off the quarantine and isola
+    model_0.set_param("Quarantine period", -1.0);
+    model_0.set_param("Isolation period", -1.0);
+
+    // Adding a single entity (population group)
+    model_0.add_entity(Entity<>("Population", dist_factory<>(0, n_agents_sz)));
+
+    // Setting the distribution function of the initial cases
+    model_0.get_virus(0).set_distribution(
+        [&n_seeds](Virus<> & v, Model<> * m) -> void {
+        for (int i = 0; i < n_seeds; ++i)
+            m->get_agents()[i].set_virus(*m, v);
+        return;
+    });
+
+    std::vector<std::vector<epiworld_double>> transitions(nsims);
+    std::vector<epiworld_double> R0s(nsims * n_seeds, -1.0);
+        
+    auto saver = tests_create_saver(transitions, R0s, n_seeds, nullptr, nullptr, nullptr);
+
+    // Average R0
+    auto calc_avg_r0 = [&R0s, nsims, n_seeds]() -> double {
+        double sum = 0.0;
+        for (auto & r0 : R0s)
+        {
+            if (r0 >= 0.0)
+                sum += r0;
+            else
+                throw std::range_error(
+                    "The R0 value is negative. This should not happen."
+                );
+        }
+        return sum / static_cast<epiworld_double>(nsims * n_seeds);
+    };
+
+    auto calc_r0_theoretical = [&contact_matrix, &model_0]() -> double {
+        
+        // Agents exit the rash state via recovery (1/rash_period) OR
+        // hospitalization (hospitalization_rate), so the expected infectious
+        // days during rash is 1 / (1/rash_period + hospitalization_rate),
+        // not rash_period itself.
+        double effective_rash_period = 1.0 / (
+            1.0 / model_0("Rash period") + model_0("Hospitalization rate")
+        );
+
+        return contact_matrix[0] * model_0("Transmission rate") * (
+            model_0("Prodromal period") +
+            effective_rash_period * (1.0 - model_0("Rash reduction contact rate"))
+        );
+    };
+
+    auto assert_and_print_r0 = [&R0s, nsims, n_seeds, calc_avg_r0, calc_r0_theoretical](
+        double delta = 0.3
+    ) -> void {
+        double R0_observed = calc_avg_r0();
+        double R0_theoretical = calc_r0_theoretical();
+
+        std::cout << "Reproductive number: "
+                  << R0_observed << " (expected ~" << R0_theoretical << ")"
+                  << std::endl;
+
+        REQUIRE_FALSE(moreless(R0_observed, R0_theoretical, delta));
+    };
+
+    // Increasing the size of the transmission rate
+    std::cout << "=============================================" << std::endl;
+    std::cout << "MeaslesMixing without hospitalization R0 test" << std::endl;
+    std::cout << "=============================================" << std::endl;
+    std::cout << "R0s with no Rash transmission:" << std::endl;
+    auto baseline_transmission_rate = model_0("Transmission rate");
+    for (size_t i = 0; i < 4; ++i)
+    {
+        model_0.
+            run_multiple(200, nsims, 1231, saver, true, false, 4);
+
+        assert_and_print_r0();
+
+        model_0.set_param("Transmission rate", model_0("Transmission rate") * 1.25);
+
+    }
+
+    model_0.set_param("Transmission rate", baseline_transmission_rate);
+    std::cout << "\nR0s with Rash transmission:" << std::endl;
+    
+    model_0.set_param("Rash reduction contact rate", 1.0);
+    for (size_t i = 0; i < 4; ++i)
+    {
+        model_0.
+            run_multiple(200, nsims, 1231, saver, true, false, 4);
+
+        std::cout << "Rash reduction: " << model_0("Rash reduction contact rate") << "; ";
+        assert_and_print_r0();
+
+        model_0.set_param("Rash reduction contact rate", 0.9 * model_0("Rash reduction contact rate"));
+
+    }
+    
+    
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -42,6 +42,7 @@ $(NAME)_SOURCES := \
 	18c-measles-mixing.cpp \
 	18d-measles-mixing.cpp \
 	18e-measles-mixing-queue.cpp \
+	18f-measles-mixing-r0s.cpp \
 	19a-measles-mixing-risk-quarantine-basic.cpp \
 	19b-measles-mixing-risk-quarantine-transitions.cpp \
 	19c-measles-mixing-risk-quarantine-durations.cpp \


### PR DESCRIPTION
This pull request introduces major improvements to the `ModelMeaslesMixing` model by implementing a two-pool infectious contact sampling mechanism that distinguishes between fully infectious (Prodromal) and reduced-contact (Rash) agents. The update refactors the codebase to use a new `SamplerMixing` class for sampling, adds a tunable parameter to control contact reduction for Rash agents, and updates documentation and tests to reflect the new model behavior.

**Key changes:**

### Model logic and sampling

* Replaced the old single-pool infectious contact sampling with a two-pool approach in `ModelMeaslesMixing`, distinguishing between Prodromal (fully infectious) and Rash (reduced-contact) agents. Rash agents now participate in infectious contact sampling at a reduced rate controlled by the new `rash_reduction_contact_rate` parameter. (`include/measles/measlesmixing.hpp`, [[1]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345L63-L82) [[2]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345L187-R172) [[3]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345L893-R743) [[4]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345L918-R768) [[5]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345R790-R798)
* Refactored sampling logic to delegate agent selection and contact sampling to the new `SamplerMixing` class, simplifying the model code and enabling the two-pool logic. (`include/measles/measlesmixing.hpp`, [[1]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345L63-L82) [[2]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345L249-R234) [[3]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345L401-R271) [[4]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345L465-R317) [[5]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345L480-R329)

### Parameters and configuration

* Added the `rash_reduction_contact_rate` parameter to the model, exposed it in the constructor, validated its range, and registered it as a model parameter. (`include/measles/measlesmixing.hpp`, [[1]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345L187-R172) [[2]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345L893-R743) [[3]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345L918-R768) [[4]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345R790-R798)
* Configured the `SamplerMixing` class within the model to use the correct infectious and available states and to respect the new parameter. (`include/measles/measlesmixing.hpp`, [include/measles/measlesmixing.hppR790-R798](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345R790-R798))

### Documentation

* Added a new section to the documentation describing the two-pool contact sampling algorithm for Rash agents, including mathematical details and code snippets to clarify the new logic. (`docs/impl/sampling-contacts.md`, [docs/impl/sampling-contacts.mdR50-R103](diffhunk://#diff-8efdfe4283b1da99470b589023a92caf9d08e997482969a54efc7a2f96b30f86R50-R103))
* Updated comments and docstrings to clarify that Rash agents have reduced infectious contact rather than being non-infectious. (`include/measles/measlesmixing.hpp`, [[1]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345L23-R25) [[2]](diffhunk://#diff-39a1266e3c6dda5febb3d81e6fc137c1be574cb0a606cc8a1de89ba768c84345L35-R37)

### Testing

* Expanded the `18a-measles-mixing.cpp` test to include scenarios with Rash agents having reduced contact rates, validating the impact on $R_0$ and outbreak metrics. (`tests/18a-measles-mixing.cpp`, [[1]](diffhunk://#diff-b998e22062db34c5683dc5c6bb2a522417bdf81b8da1f0b50d299630819ebefdL13-R17) [[2]](diffhunk://#diff-b998e22062db34c5683dc5c6bb2a522417bdf81b8da1f0b50d299630819ebefdR202-R259)
* Minor cleanup and clarification in test macros for $R_0$ calculation. (`tests/14c-measles.cpp`, [tests/14c-measles.cppL5-R10](diffhunk://#diff-9ca34fa0fe7c9beb576ba7e686633ee16f8d9db21b79a4d10248e27b6afc3922L5-R10))